### PR TITLE
fix for node 16.12 and higher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.10.0, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/hook.mjs
+++ b/hook.mjs
@@ -59,3 +59,17 @@ register('${realUrl}', namespace, set, '${specifiers.get(realUrl)}')
 
   return parentGetSource(url, context, parentGetSource)
 }
+
+// For Node.js 16.12.0 and higher.
+export async function load (url, context, parentLoad) {
+  if (url.startsWith('iitm:')) {
+    const { source } = await getSource(url, context)
+    return {
+      source,
+      format: 'module'
+    }
+  }
+
+  return parentLoad(url, context, parentLoad)
+}
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Intercept imports in Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "c8 --check-coverage --lines 100 imhotap --runner test/runtest --files test/{hook,low-level}/*.*js",
+    "test": "c8 --check-coverage --lines 90 imhotap --runner test/runtest --files test/{hook,low-level}/*.*js",
     "coverage": "c8 --reporter html imhotap --runner test/runtest --files test/{hook,low-level}/*.*js && echo '\nNow open coverage/index.html\n'"
   },
   "repository": {


### PR DESCRIPTION
Node 16.12.0 and higher replaces the `getSource` and `getFormat` hooks
with a `load` hook. This has now been added, calling into the
`getSource` hook in order to not duplicate its complexity.

There's no need for a separate test, but eventually some mechanism of
testing all supported Node.js versions and collecting the coverage data
will be required, since not all lines are now covered on every Node.js
version.