### PR TITLE
WIP: add optional argument to specify which modules to patch

### DIFF
--- a/filtered-hook.mjs
+++ b/filtered-hook.mjs
@@ -1,0 +1,6 @@
+import { createHook } from './hook.js'
+import path from 'path'
+
+const { load, resolve, getFormat, getSource } = createHook(import.meta, new Set([path.join(import.meta.url, '../test/fixtures/export-types/default-expression-array.mjs').replace(':/', ':///')]))
+
+export { load, resolve, getFormat, getSource }

--- a/filtered-hook.mjs
+++ b/filtered-hook.mjs
@@ -1,6 +1,0 @@
-import { createHook } from './hook.js'
-import path from 'path'
-
-const { load, resolve, getFormat, getSource } = createHook(import.meta, new Set([path.join(import.meta.url, '../test/fixtures/export-types/default-expression-array.mjs').replace(':/', ':///')]))
-
-export { load, resolve, getFormat, getSource }

--- a/hook.js
+++ b/hook.js
@@ -238,7 +238,7 @@ function createHook (meta, moduleList = {}) {
       if (moduleList.has(specifier)) { // if specifier is a module name present in moduleList
         patch = true
       } else {
-        for (const mod of moduleList.key) { // if specifier
+        for (const mod of moduleList.key) { // if specifier is a file path
           if (specifier.includes(mod)) {
             for (const path of moduleList[mod]) {
               if (specifier.endsWith(mod + path) || specifier.endsWith(mod + path + '/')) {
@@ -259,7 +259,7 @@ function createHook (meta, moduleList = {}) {
       const url = await parentResolve(newSpecifier, context, parentResolve)
       if (parentURL === '' && !EXTENSION_RE.test(url.url)) {
         entrypoint = url.url
-        return { url: url.url, format: 'commonjs' } // early return, find out format
+        return { url: url.url, format: 'commonjs' }
       }
 
       if (isIitm(parentURL, meta) || hasIitm(parentURL)) {

--- a/hook.js
+++ b/hook.js
@@ -228,38 +228,65 @@ function addIitm (url) {
   return needsToAddFileProtocol(urlObj) ? 'file:' + urlObj.href : urlObj.href
 }
 
-function createHook (meta) {
-  async function resolve (specifier, context, parentResolve) {
-    const { parentURL = '' } = context
+// moduleList is an optional Map specifiying which modules need IITM patching
+// format: { moduleName : ['/file1.js', '/file2.js'] }
+function createHook (meta, moduleList={}) {
+  async function resolve (specifier, context, parentResolve, moduleList) {
+    let patch = true
+    if (moduleList.size) {
+      patch = false // do not patch unless specifier is in moduleList
+      if (moduleList.has(specifier)) { // if specifier is a module name present in moduleList
+        patch = true
+      } else {
+        for (let mod of moduleList.key) { // if specifier
+          if (specifier.includes(mod)) {
+            for (let path of moduleList[mod]) {
+              if (specifier.endsWith(mod + path) || specifier.endsWith(mod + path + '/')) {
+                patch = true
+                continue
+              }
+            }
+          }
+        }
+      }
+    }
+    if (patch) {
+      const { parentURL = '' } = context
+      const newSpecifier = deleteIitm(specifier)
+      if (isWin && parentURL.indexOf('file:node') === 0) {
+        context.parentURL = ''
+      }
+      const url = await parentResolve(newSpecifier, context, parentResolve)
+      if (parentURL === '' && !EXTENSION_RE.test(url.url)) {
+        entrypoint = url.url
+        return { url: url.url, format: 'commonjs' } // early return, find out format
+      }
+
+      if (isIitm(parentURL, meta) || hasIitm(parentURL)) {
+        return url
+      }
+
+      // Node.js v21 renames importAssertions to importAttributes
+      if (
+        (context.importAssertions && context.importAssertions.type === 'json') ||
+        (context.importAttributes && context.importAttributes.type === 'json')
+      ) {
+        return url
+      }
+
+      specifiers.set(url.url, specifier)
+      return {
+        url: addIitm(url.url),
+        shortCircuit: true,
+        format: url.format
+      }
+    }
     const newSpecifier = deleteIitm(specifier)
     if (isWin && parentURL.indexOf('file:node') === 0) {
       context.parentURL = ''
     }
     const url = await parentResolve(newSpecifier, context, parentResolve)
-    if (parentURL === '' && !EXTENSION_RE.test(url.url)) {
-      entrypoint = url.url
-      return { url: url.url, format: 'commonjs' }
-    }
-
-    if (isIitm(parentURL, meta) || hasIitm(parentURL)) {
-      return url
-    }
-
-    // Node.js v21 renames importAssertions to importAttributes
-    if (
-      (context.importAssertions && context.importAssertions.type === 'json') ||
-      (context.importAttributes && context.importAttributes.type === 'json')
-    ) {
-      return url
-    }
-
-    specifiers.set(url.url, specifier)
-
-    return {
-      url: addIitm(url.url),
-      shortCircuit: true,
-      format: url.format
-    }
+    return { url: url.url, format: url.format }
   }
 
   const iitmURL = new URL('lib/register.js', meta.url).toString()

--- a/hook.js
+++ b/hook.js
@@ -1,10 +1,12 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+const path = require('path')
 
 const { randomBytes } = require('crypto')
 const specifiers = new Map()
 const isWin = process.platform === 'win32'
+const hookURL = 'file://' + path.join(__dirname, './hook.js')
 
 // FIXME: Typescript extensions are added temporarily until we find a better
 // way of supporting arbitrary extensions
@@ -31,7 +33,7 @@ function hasIitm (url) {
 }
 
 function isIitm (url, meta) {
-  return url === meta.url || url === meta.url.replace('hook.mjs', 'hook.js')
+  return url === meta.url || url === hookURL
 }
 
 function deleteIitm (url) {
@@ -231,8 +233,9 @@ function addIitm (url) {
 // moduleList is an optional Set specifiying which modules need IITM patching
 // moduleList contains full file paths
 // if moduleList is empty, IITM patches everything
-function createHook (meta, moduleList = new Set()) {
+function createHook (meta) {
   async function resolve (specifier, context, parentResolve) {
+    const moduleList = process.env.MODULES_TO_PATCH ? new Set(process.env.MODULES_TO_PATCH.split(', ')) : new Set()
     const { parentURL = '' } = context
     const newSpecifier = deleteIitm(specifier)
     if (isWin && parentURL.indexOf('file:node') === 0) {
@@ -241,6 +244,7 @@ function createHook (meta, moduleList = new Set()) {
     const url = await parentResolve(newSpecifier, context, parentResolve)
     if (parentURL === '' && !EXTENSION_RE.test(url.url)) {
       entrypoint = url.url
+      // console.log(1, parentURL)
       return { url: url.url, format: 'commonjs' }
     }
 
@@ -258,10 +262,12 @@ function createHook (meta, moduleList = new Set()) {
       (context.importAssertions && context.importAssertions.type === 'json') ||
       (context.importAttributes && context.importAttributes.type === 'json')
     ) {
+      // console.log(3, url.url)
       return url
     }
 
     specifiers.set(url.url, specifier)
+    // console.log(4, url.url)
     return {
       url: addIitm(url.url),
       shortCircuit: true,

--- a/hook.js
+++ b/hook.js
@@ -230,17 +230,17 @@ function addIitm (url) {
 
 // moduleList is an optional Map specifiying which modules need IITM patching
 // format: { moduleName : ['/file1.js', '/file2.js'] }
-function createHook (meta, moduleList={}) {
-  async function resolve (specifier, context, parentResolve, moduleList) {
+function createHook (meta, moduleList = {}) {
+  async function resolve (specifier, context, parentResolve) {
     let patch = true
     if (moduleList.size) {
       patch = false // do not patch unless specifier is in moduleList
       if (moduleList.has(specifier)) { // if specifier is a module name present in moduleList
         patch = true
       } else {
-        for (let mod of moduleList.key) { // if specifier
+        for (const mod of moduleList.key) { // if specifier
           if (specifier.includes(mod)) {
-            for (let path of moduleList[mod]) {
+            for (const path of moduleList[mod]) {
               if (specifier.endsWith(mod + path) || specifier.endsWith(mod + path + '/')) {
                 patch = true
                 continue
@@ -282,7 +282,7 @@ function createHook (meta, moduleList={}) {
       }
     }
     const newSpecifier = deleteIitm(specifier)
-    if (isWin && parentURL.indexOf('file:node') === 0) {
+    if (isWin) {
       context.parentURL = ''
     }
     const url = await parentResolve(newSpecifier, context, parentResolve)

--- a/hook.js
+++ b/hook.js
@@ -244,7 +244,7 @@ function createHook (meta, moduleList = new Set()) {
       return { url: url.url, format: 'commonjs' }
     }
 
-    // early return if
+    // early return if a moduleList is non-empty and does not contain the fully resolved url
     if (moduleList.size && !moduleList.has(url.url) && url.url.startsWith('file:///')) {
       return { url: url.url, format: url.format }
     }

--- a/test/generic-loader.mjs
+++ b/test/generic-loader.mjs
@@ -12,6 +12,8 @@ const filename = process.env.IITM_TEST_FILE
 export const { load, resolve, getFormat, getSource } =
   filename.includes('disabled')
     ? {}
-    : (path.extname(filename).slice(-2) === 'ts' ? tsLoader
-      : filename.endsWith('filtered-export.mjs') ? filteredLoader
-        : regularLoader)
+    : (path.extname(filename).slice(-2) === 'ts'
+        ? tsLoader
+        : filename.endsWith('filtered-export.mjs')
+            ? filteredLoader
+            : regularLoader)

--- a/test/generic-loader.mjs
+++ b/test/generic-loader.mjs
@@ -12,5 +12,6 @@ const filename = process.env.IITM_TEST_FILE
 export const { load, resolve, getFormat, getSource } =
   filename.includes('disabled')
     ? {}
-    : (path.extname(filename).slice(-2) === 'ts' ? tsLoader :
-    filename.endsWith('filtered-export.mjs') ? filteredLoader: regularLoader)
+    : (path.extname(filename).slice(-2) === 'ts' ? tsLoader
+      : filename.endsWith('filtered-export.mjs') ? filteredLoader
+        : regularLoader)

--- a/test/generic-loader.mjs
+++ b/test/generic-loader.mjs
@@ -4,6 +4,7 @@
 
 import * as tsLoader from './typescript/iitm-ts-node-loader.mjs'
 import * as regularLoader from '../hook.mjs'
+import * as filteredLoader from '../filtered-hook.mjs'
 import path from 'path'
 
 const filename = process.env.IITM_TEST_FILE
@@ -11,4 +12,5 @@ const filename = process.env.IITM_TEST_FILE
 export const { load, resolve, getFormat, getSource } =
   filename.includes('disabled')
     ? {}
-    : (path.extname(filename).slice(-2) === 'ts' ? tsLoader : regularLoader)
+    : (path.extname(filename).slice(-2) === 'ts' ? tsLoader :
+    filename.endsWith('filtered-export.mjs') ? filteredLoader: regularLoader)

--- a/test/generic-loader.mjs
+++ b/test/generic-loader.mjs
@@ -4,16 +4,16 @@
 
 import * as tsLoader from './typescript/iitm-ts-node-loader.mjs'
 import * as regularLoader from '../hook.mjs'
-import * as filteredLoader from '../filtered-hook.mjs'
 import path from 'path'
 
 const filename = process.env.IITM_TEST_FILE
+const filteredModuleTest = path.join(import.meta.url, '../hook/filtered-export.mjs').slice(5)
+
+if (filename === filteredModuleTest) {
+  process.env.MODULES_TO_PATCH = path.join(import.meta.url, '../fixtures/export-types/default-expression-array.mjs').replace(':/', ':///')
+}
 
 export const { load, resolve, getFormat, getSource } =
   filename.includes('disabled')
     ? {}
-    : (path.extname(filename).slice(-2) === 'ts'
-        ? tsLoader
-        : filename.endsWith('filtered-export.mjs')
-            ? filteredLoader
-            : regularLoader)
+    : (path.extname(filename).slice(-2) === 'ts' ? tsLoader : regularLoader)

--- a/test/hook/filtered-export.mjs
+++ b/test/hook/filtered-export.mjs
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+import Hook from '../../index.js'
+import a from '../fixtures/export-types/default-expression-array.mjs'
+import n from '../fixtures/export-types/default-expression-num.mjs'
+import { strictEqual } from 'assert'
+
+Hook((exports, name) => {
+  if (name.match(/default-expression-array\.m?js/)) {
+    exports.default[0] += 1
+  } else if (name.match(/default-expression-num\.m?js/)) {
+    exports.default += 1
+  }
+})
+
+strictEqual(a[0], 2)
+strictEqual(n, 1)

--- a/test/hook/filtered-export.mjs
+++ b/test/hook/filtered-export.mjs
@@ -15,5 +15,7 @@ Hook((exports, name) => {
   }
 })
 
+console.log('a', a)
+console.log('n', n)
 strictEqual(a[0], 2)
 strictEqual(n, 1)

--- a/test/hook/filtered-export.mjs
+++ b/test/hook/filtered-export.mjs
@@ -15,7 +15,5 @@ Hook((exports, name) => {
   }
 })
 
-console.log('a', a)
-console.log('n', n)
 strictEqual(a[0], 2)
 strictEqual(n, 1)


### PR DESCRIPTION
Add the option to specify a list of modules to patch through env var MODULES_TO_PATCH. This allows IITM to ignore some files, potentially resulting in a performance gain. This also might help eliminating IITM errors since less files are being patched.
If MODULES_TO_PATCH is not specified, everything behaves as usual.