### PR TITLE
fix: CJS `require('.')` resolution

### DIFF
--- a/lib/get-exports.js
+++ b/lib/get-exports.js
@@ -43,6 +43,9 @@ async function getCjsExports (url, context, parentLoad, source) {
           full.add(each)
         }
       } else {
+        if (re === '.') {
+          re = './'
+        }
         // Resolve the re-exported module relative to the current module.
         const newUrl = pathToFileURL(require.resolve(re, { paths: [dirname(fileURLToPath(url))] })).href
         for (const each of await getExports(newUrl, context, parentLoad)) {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,1 @@
+module.exports.foo = 'something'

--- a/test/fixtures/require-root.js
+++ b/test/fixtures/require-root.js
@@ -1,0 +1,1 @@
+module.exports = { ...require('.') }

--- a/test/hook/require-root-cjs.mjs
+++ b/test/hook/require-root-cjs.mjs
@@ -1,0 +1,12 @@
+import Hook from '../../index.js'
+import { foo } from '../fixtures/require-root.js'
+import { strictEqual } from 'assert'
+
+Hook((exports, name) => {
+  if (name.endsWith('require-root.js')) {
+    strictEqual(exports.foo, 'something')
+    exports.foo += '-wrap'
+  }
+})
+
+strictEqual(foo, 'something-wrap')


### PR DESCRIPTION
Closes #116 and closes #97

While trying to create a minimal reproduction for #106, I found that the issue was caused by the following CommonJs in `@prisma/client`:
```ts
module.exports = { ...require('.') }
```

`require('.')` was getting resolved to `{cwd}/index.js` whereas it should be resolving to `./`, ie. the index file in the same directory as the current file `./index.js`.