### PR TITLE
fix: Include source url for parsing failures

### DIFF
--- a/lib/get-exports.js
+++ b/lib/get-exports.js
@@ -92,23 +92,28 @@ async function getExports (url, context, parentLoad) {
     source = readFileSync(fileURLToPath(url), 'utf8')
   }
 
-  if (format === 'module') {
-    return getEsmExports(source)
-  }
+  try {
+    if (format === 'module') {
+      return getEsmExports(source)
+    }
 
-  if (format === 'commonjs') {
-    return getCjsExports(url, context, parentLoad, source)
-  }
+    if (format === 'commonjs') {
+      return getCjsExports(url, context, parentLoad, source)
+    }
 
-  // At this point our `format` is either undefined or not known by us. Fall
-  // back to parsing as ESM/CJS.
-  const esmExports = getEsmExports(source)
-  if (!esmExports.length) {
-    // TODO(bengl) it's might be possible to get here if somehow the format
-    // isn't set at first and yet we have an ESM module with no exports.
-    // I couldn't construct an example that would do this, so maybe it's
-    // impossible?
-    return getCjsExports(url, context, parentLoad, source)
+    // At this point our `format` is either undefined or not known by us. Fall
+    // back to parsing as ESM/CJS.
+    const esmExports = getEsmExports(source)
+    if (!esmExports.length) {
+      // TODO(bengl) it's might be possible to get here if somehow the format
+      // isn't set at first and yet we have an ESM module with no exports.
+      // I couldn't construct an example that would do this, so maybe it's
+      // impossible?
+      return getCjsExports(url, context, parentLoad, source)
+    }
+  }
+  catch (cause) {
+
   }
 }
 

--- a/lib/get-exports.js
+++ b/lib/get-exports.js
@@ -98,7 +98,7 @@ async function getExports (url, context, parentLoad) {
     }
 
     if (format === 'commonjs') {
-      return getCjsExports(url, context, parentLoad, source)
+      return await getCjsExports(url, context, parentLoad, source)
     }
 
     // At this point our `format` is either undefined or not known by us. Fall
@@ -109,11 +109,12 @@ async function getExports (url, context, parentLoad) {
       // isn't set at first and yet we have an ESM module with no exports.
       // I couldn't construct an example that would do this, so maybe it's
       // impossible?
-      return getCjsExports(url, context, parentLoad, source)
+      return await getCjsExports(url, context, parentLoad, source)
     }
-  }
-  catch (cause) {
-
+  } catch (cause) {
+    const err = new Error(`Failed to parse '${url}'`)
+    err.cause = cause
+    throw err
   }
 }
 


### PR DESCRIPTION
Since #106 might not get merged, I cherry picked the improvements to logged error messages when module wrapping fails due to parsing failures.

`processModule` may parse multiple files in the process of wrapping a module so it's important to log the exact file the fails parsing.

```
Error: 'import-in-the-middle' failed to wrap 'file:///Users/tim/Documents/Repositories/import-in-the-middle/test/fixtures/json-attributes.mjs'
    at load (/Users/tim/Documents/Repositories/import-in-the-middle/hook.js:306:21)
    at async nextLoad (node:internal/modules/esm/hooks:750:22)
    at async Hooks.load (node:internal/modules/esm/hooks:383:20)
    at async MessagePort.handleMessage (node:internal/modules/esm/worker:199:18) {
  cause: Error: Failed to parse 'file:///Users/tim/Documents/Repositories/import-in-the-middle/test/fixtures/json-attributes.mjs'
      at getExports (/Users/tim/Documents/Repositories/import-in-the-middle/lib/get-exports.js:115:17)
      at async processModule (/Users/tim/Documents/Repositories/import-in-the-middle/hook.js:131:23)
      at async load (/Users/tim/Documents/Repositories/import-in-the-middle/hook.js:269:25)
      at async nextLoad (node:internal/modules/esm/hooks:750:22)
      at async Hooks.load (node:internal/modules/esm/hooks:383:20)
      at async MessagePort.handleMessage (node:internal/modules/esm/worker:199:18) {
    cause: SyntaxError: Unexpected token (1:40)
        at pp$4.raise (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn/dist/acorn.js:3573:15)
        at pp$9.unexpected (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn/dist/acorn.js:772:10)
        at pp$9.semicolon (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn/dist/acorn.js:749:68)
        at Parser.parseImport (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn-import-attributes/lib/index.js:242:12)
        at pp$8.parseStatement (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn/dist/acorn.js:948:51)
        at pp$8.parseTopLevel (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn/dist/acorn.js:829:23)
        at Parser.parse (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn/dist/acorn.js:601:17)
        at Function.parse (/Users/tim/Documents/Repositories/import-in-the-middle/node_modules/acorn/dist/acorn.js:651:37)
        at getEsmExports (/Users/tim/Documents/Repositories/import-in-the-middle/lib/get-esm-exports.js:37:23)
        at getExports (/Users/tim/Documents/Repositories/import-in-the-middle/lib/get-exports.js:97:14) {
      pos: 40,
      loc: [Position],
      raisedAt: 44
    }
  }
}
```