### PR TITLE
Introduce failing test to recreate openai shim issue

### DIFF
--- a/test/fixtures/side-effects/core.mjs
+++ b/test/fixtures/side-effects/core.mjs
@@ -1,0 +1,2 @@
+import { kind as shimsKind } from "./shims.mjs";
+export { shimsKind };

--- a/test/fixtures/side-effects/registry.mjs
+++ b/test/fixtures/side-effects/registry.mjs
@@ -1,0 +1,9 @@
+export let kind = undefined;
+
+export function setShims(shims) {
+  if (kind) {
+    throw new Error(`shims already set to ${kind}`);
+  }
+
+  kind = shims.kind;
+}

--- a/test/fixtures/side-effects/runtime.mjs
+++ b/test/fixtures/side-effects/runtime.mjs
@@ -1,0 +1,5 @@
+export function getRuntime() {
+  return {
+    kind: "node",
+  };
+}

--- a/test/fixtures/side-effects/shims.mjs
+++ b/test/fixtures/side-effects/shims.mjs
@@ -1,0 +1,8 @@
+import * as shims from "./registry.mjs";
+import * as auto from "./runtime.mjs";
+
+if (!shims.kind) {
+  shims.setShims(auto.getRuntime());
+}
+
+export * from "./registry.mjs";

--- a/test/hook/side-effects.mjs
+++ b/test/hook/side-effects.mjs
@@ -1,0 +1,4 @@
+import * as core from "../fixtures/side-effects/core.mjs";
+import { strictEqual } from "assert";
+
+strictEqual(core.shimsKind, "node");


### PR DESCRIPTION
Using iitm 1.8.1 in an ESM project that imports the `openai` package leads to the following exception:

```
TypeError: getDefaultAgent is not a function
```

`getDefaultAgent` is part of the openai [shims](https://github.com/openai/openai-node/blob/master/src/_shims/index.mjs) system, which automatically sets certain platform/runtime specific values using module side-effects. I've recreated a simplified version of this issue in a test file (I may have put the test file in the wrong place, please advise and I can move it if needed). You can see the test pass with the following:

```sh
node --require ./test/version-check.js  test/hook/side-effects.mjs
```

And fail with the loader added:

```sh
node --require ./test/version-check.js --experimental-loader ./test/generic-loader.mjs test/hook/side-effects.mjs

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ undefined
- 'node'
    at file:///Users/eric/code/triggerdotdev/opensource/import-in-the-middle/test/hook/side-effects.mjs:4:1
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: undefined,
  expected: 'node',
  operator: 'strictEqual'
}
```

I'm not exactly sure what the issue is, but it does look like possibly the second import of `registry.mjs` in the shims file maybe just uses a module cache, instead of re-importing the module:

```
import * as shims from "./registry.mjs";
import * as auto from "./runtime.mjs";

if (!shims.kind) {
  shims.setShims(auto.getRuntime());
}

export * from "./registry.mjs";
```