### PR TITLE
feat: Add package.json engines to pin Node 12+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
     strategy:
       matrix:
         node-version:
+          # We test against the earliest Node 12 version because that is what we
+          # support with our current engines config.
+          - 12.0.0
           - 12.x
           - 14.x
           - 16.10.0

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "hook",
     "hooks"
   ],
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "author": "Bryan English <bryan.english@datadoghq.com>",
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
We should make it clear that this package only supports Node 12+. This also allows us to more easily bump the minimum Node version for future majors.