### PR TITLE
ref: Vendor in module-details-from-path

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
 const path = require('path')
-const parse = require('module-details-from-path')
 const { fileURLToPath } = require('url')
 
+const moduleDetailsFromPath = require('./lib/module-details-from-path')
 const {
   importHooks,
   specifiers,
@@ -56,7 +56,7 @@ function Hook (modules, options, hookFn) {
           name = fileURLToPath(name)
         } catch (e) {}
       }
-      const details = parse(name)
+      const details = moduleDetailsFromPath(name)
       if (details) {
         name = details.name
         baseDir = details.basedir

--- a/lib/module-details-from-path.js
+++ b/lib/module-details-from-path.js
@@ -1,0 +1,89 @@
+'use strict'
+
+//  Vendored from https://github.com/watson/module-details-from-path/tree/6b231a35fae6b7f5b6b12b55fbb75fd4913afe5a
+// The MIT License (MIT)
+
+// Copyright (c) 2016 Thomas Watson Steen
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// This has been vendored to reduce the number of dependencies required to run this module, update
+// syntax to more modern node versions and functionality to return the `path` has been removed.
+
+const path = require('path')
+
+/**
+ * @typedef {Object} ModuleDetails - an object containing module details
+ * @property {string} name - the name of the module
+ * @property {number} basedir - the basedir of the module
+ */
+
+/**
+ * Get module details from a file path.
+ *
+ * @param file {string} - The file path to get module details from.
+ * @returns {ModuleDetails|undefined} Module details or undefined if the details cannot be
+ * parsed from the path.
+ *
+ * @example
+ * ```js
+ * const details = moduleDetailsFromPath('/Users/test/code/node_modules/drizzle-orm/node_modules/mysql/lib/protocol/sequences/Query.js')
+ *
+ * // emits 'mysql
+ * console.log(details.name)
+ *
+ * // emits '/Users/test/code/node_modules/drizzle-orm/node_modules/mysql'
+ * console.log(details.basedir)
+ * ```
+ */
+function moduleDetailsFromPath (file) {
+  const segments = file.split(path.sep)
+  const index = segments.lastIndexOf('node_modules')
+
+  const packageName = segments[index + 1]
+
+  if (index === -1 || !packageName) {
+    return
+  }
+
+  const basedir = segments.slice(0, index + 2).join(path.sep)
+
+  // If packageName is a scope, for example `@babel`, we need
+  // to include the next segment in the package name. This would
+  // make sure `@babel/core` is emitted instead of just `@babel`.
+  const scoped = packageName[0] === '@'
+  if (scoped) {
+    const scopedPackageName = segments[index + 2]
+    if (!scopedPackageName) {
+      return
+    }
+
+    return {
+      name: `${packageName}/${scopedPackageName}`,
+      basedir
+    }
+  }
+
+  return {
+    name: packageName,
+    basedir
+  }
+}
+
+module.exports = moduleDetailsFromPath

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "acorn": "^8.8.2",
     "acorn-import-attributes": "^1.9.5",
-    "cjs-module-lexer": "^1.2.2",
-    "module-details-from-path": "^1.0.3"
+    "cjs-module-lexer": "^1.2.2"
   }
 }


### PR DESCRIPTION
This PR vendors in [`module-details-from-path`](https://www.npmjs.com/package/module-details-from-path) and rewrites it to match the syntax we use for import-in-the-middle.

I generally believe that less dependencies for diagnostics tooling is a [good thing](https://develop.sentry.dev/sdk/philosophy/#dependencies-cost) but there are other reasons to do this.

1. Pulling this in means it becomes way easier for us to adjust it in the future, which I think we will do with the next couple of cleanups happening in the repo. I also hope that my extra comments helps make this easier to understand for external contributors in addition.
2. Right now using `module-details-from-path` pulls in a couple of un-needed files (testing, travis config). We can alleviate this for the ~8.3 mil weekly downloads `import-in-the-middle` gets

<img width="794" alt="image" src="https://github.com/nodejs/import-in-the-middle/assets/18689448/70f95692-fde0-413a-b042-a14eaaaed374">

One thing to note about the implementation is that I elected to add JSDoc based types. In my opinion adding a ts build process may be too heavy (unless we want to dual emit CJS/ESM from the lib), so I think this is a good middleground to get better intellisense while we are working on refactoring the lib. Happy to remove if folks thing this is unnecessary.

This PR came from me trying to reduce the import graph of a project that uses OpenTelemetry. Here's [`@opentelemetry/instrumentation`](https://npmgraph.js.org/?q=%40opentelemetry%2Finstrumentation) for example.