### PR TITLE
chore: Add `CODE_OF_CONDUCT`, `GOVERNANCE` and update `CONTRIBUTING`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of Conduct
+
+The Code of Conduct, which applies to this project, can be found at
+https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,34 @@
-# Contributing to import-in-the-middle
+# Contributing to `import-in-the-middle`
 
-First of all, thanks for contributing!
+## Code of Conduct
 
-* If you think you've found an issue, please open a Github issue.
-* To propose improvements, feel free to submit a PR.
+Please read the
+[Code of Conduct](https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md)
+which explains the minimum behavior expectations for `import-in-the-middle` contributors.
+
+<a id="developers-certificate-of-origin"></a>
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,28 @@
+# `import-in-the-middle` Project Governance
+
+## Collaborators
+
+`import-in-the-middle` core collaborators maintain the
+[nodejs/import-in-the-middle](https://github.com/nodejs/import-in-the-middle)
+GitHub repository.
+The GitHub team for `import-in-the-middle` core collaborators is
+[@nodejs/import-in-the-middle-maintainers](https://github.com/orgs/nodejs/teams/import-in-the-middle-maintainers). 
+Collaborators have commit access to the
+[nodejs/import-in-the-middle](https://github.com/nodejs/import-in-the-middle)
+repository.
+
+Both collaborators and non-collaborators may propose changes to the `import-in-the-middle`
+source code. The mechanism to propose such a change is a GitHub pull request.
+Collaborators review and merge (_land_) pull requests.
+
+## PR Approval
+
+Two collaborators must approve a pull request before the pull request can land.
+Approving a pull request indicates that the collaborator accepts responsibility
+for the change. Approval must be from collaborators who are not authors of the
+change and at least one approval must be from a collaborator outside the authors
+direct team. 
+
+If a collaborator opposes a proposed change, then the change cannot land. Often,
+discussions or further changes result in collaborators removing their
+opposition. 


### PR DESCRIPTION
Closes #122

- `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` come from other Node repos
- `GOVERNANCE.md` was copied from the Nodejs repo with lots of irrelevent detail removed and PR approvals modified.