### PR TITLE
chore: add release-please github token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "57d2459748492abd55e04a679d8b5752b90dfab4",
   "packages": {
     ".": {
       "pull-request-title-pattern": "chore: release v${version}",


### PR DESCRIPTION
I'll replace this token with @nodejs-github-bot's one ASAP. At the moment it is my token with 30 days expiration.

Also adds a `bootstrap-sha` to exclude commits before 1.8.1: https://github.com/nodejs/import-in-the-middle/pull/135#issuecomment-2213936224