### PR TITLE
chore: npm ignore several files used for dev

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,9 @@ package-lock.json
 yarn.lock
 node_modules
 coverage
+.editorconfig
+.eslintrc.yaml
+.release-please-manifest.json
+release-please-config.json
+tsconfig.json
+test


### PR DESCRIPTION
I noticed that there are many files included in the npm package that aren't necessary at run time, even from when Datadog was still doing releases.

Definitely open to conversation about these changes.

```
.editorconfig -> required for local development
.eslintrc.yaml -> required for local development
.release-please-manifest.json -> required for CI
release-please-config.json -> required for CI
tsconfig.json -> required for local development only? Is this used by library consumers?
test -> required for local development, CI
```

## 1.8.1

![iitm-181](https://github.com/nodejs/import-in-the-middle/assets/551402/699c9c59-3a45-4086-8bf6-ad61475cb09f)

## 1.9.0

![iitm-190](https://github.com/nodejs/import-in-the-middle/assets/551402/2ab5e038-ac93-4c02-a185-7635b556dcac)
