### PR TITLE
fix: Use correct `format` when resolving exports from sub-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "imhotap": "^2.1.0",
     "openai": "^4.47.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "vue": "^3.4.31"
   },
   "dependencies": {
     "acorn": "^8.8.2",

--- a/test/hook/vue-server-renderer.mjs
+++ b/test/hook/vue-server-renderer.mjs
@@ -1,0 +1,4 @@
+import { strictEqual } from 'assert'
+import * as lib from 'vue/server-renderer'
+
+strictEqual(typeof lib.renderToString, 'function')

--- a/test/hook/vue-server-renderer.mjs
+++ b/test/hook/vue-server-renderer.mjs
@@ -1,3 +1,4 @@
+// https://github.com/nodejs/import-in-the-middle/issues/139
 import { strictEqual } from 'assert'
 import * as lib from 'vue/server-renderer'
 


### PR DESCRIPTION
Closes #139

When we resolve sub-modules to get their exports, `parentResolve` can return a different `format` to the current module type and this should be used when loading the module source!

This change is potnetially a one-liner but I refactored the code a bit to avoid initially setting `let` variables as undefined only to set them later in an if/else. 