### PR TITLE
fix: Don't wrap native modules

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -297,6 +297,10 @@ function createHook (meta) {
       return result
     }
 
+    if (!result.url.endsWith('.node')) {
+      return result
+    }
+
     // Node.js v21 renames importAssertions to importAttributes
     if (
       (context.importAssertions && context.importAssertions.type === 'json') ||


### PR DESCRIPTION
Closes #138

I've tested this working locally but I'm stuggling to add a test for this which will work relaibly cross platform. 

Does anyone know of a native module that's published not hidden behind JavaScript wrappers that includes pre-built binaries for cross platform support?

I'd prefer it if we didn't impose requiring a native toolchain just to `npm install`!