### PR TITLE
fix: Use correct `format` when resolving exports from relative paths

### DIFF
--- a/test/hook/vue-server-renderer.mjs
+++ b/test/hook/vue-server-renderer.mjs
@@ -1,5 +1,8 @@
-// https://github.com/nodejs/import-in-the-middle/issues/139
 import { strictEqual } from 'assert'
-import * as lib from 'vue/server-renderer'
+// https://github.com/nodejs/import-in-the-middle/issues/139
+import * as libServer from 'vue/server-renderer'
+// https://github.com/nodejs/import-in-the-middle/issues/144
+import * as lib from 'vue'
 
-strictEqual(typeof lib.renderToString, 'function')
+strictEqual(typeof libServer.renderToString, 'function')
+strictEqual(typeof lib.ref, 'function')


### PR DESCRIPTION
Closes #144

So I fixed the transition from ESM to CJS when loading sub-modules for export evaluation via a bare specifier in #140... but unsurprisingly this is also required when resolving realtive paths too.

As @jsumners-nr once said:
> we seem to be playing whack-a-mole with the ludicrous number of permutations