### PR TITLE
fix: `node:` prefixed build-in modules with `include`/`exclude`

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -117,6 +117,11 @@ function isBareSpecifier (specifier) {
   }
 }
 
+/**
+ * Determines whether the input is a bare specifier, file URL or a regular expression.
+ *
+ * - node: prefixed URL strings are considered bare specifiers in this context.
+ */
 function isBareSpecifierFileUrlOrRegex (input) {
   if (input instanceof RegExp) {
     return true
@@ -140,6 +145,13 @@ function isBareSpecifierFileUrlOrRegex (input) {
   }
 }
 
+/**
+ * Ensure an array only contains bare specifiers, file URLs or regular expressions.
+ *
+ * - We consider node: prefixed URL string as bare specifiers in this context.
+ * - For node built-in modules, we add additional node: prefixed modules to the
+ *   output array.
+ */
 function ensureArrayWithBareSpecifiersFileUrlsAndRegex (array, type) {
   if (!Array.isArray(array)) {
     return undefined

--- a/test/register/v18.19-include-builtin.mjs
+++ b/test/register/v18.19-include-builtin.mjs
@@ -1,0 +1,20 @@
+import { register } from 'module'
+import Hook from '../../index.js'
+import { strictEqual } from 'assert'
+
+register('../../hook.mjs', import.meta.url, { data: { include: ['node:util', 'os'] } })
+
+const hooked = []
+
+Hook((exports, name) => {
+  hooked.push(name)
+})
+
+await import('util')
+await import('node:os')
+await import('fs')
+await import('path')
+
+strictEqual(hooked.length, 2)
+strictEqual(hooked[0], 'util')
+strictEqual(hooked[1], 'os')


### PR DESCRIPTION
@trentm found a bug in `node:` prefixed built-in modules when using `include` and `exclude`:
https://github.com/nodejs/import-in-the-middle/pull/146#issuecomment-2253093908

This PR fixes that bug and adds some tests for it.