### PR TITLE
fix: do nothing if target does not exist in getters map

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -17,7 +17,12 @@ const proxyHandler = {
     if (name === Symbol.toStringTag) {
       return 'Module'
     }
-    return getters.get(target)[name]()
+
+    try {
+      return getters.get(target)[name]()
+    } catch {
+      return
+    }
   },
 
   defineProperty (target, property, descriptor) {


### PR DESCRIPTION
https://github.com/nodejs/import-in-the-middle/pull/153 introduced the `getters` map to allow for multiple hooks. However, there may exist edge cases where the name does not exist in the target, resulting in the following error:

```
/project/path/node_modules/import-in-the-middle/lib/register.js:20
    return getters.get(target)[name]()
                                    ^

TypeError: getters.get(...)[name] is not a function
    at Object.get (/project/path/node_modules/import-in-the-middle/lib/register.js:20:37)
    at /project/path/node_modules/dd-trace/packages/datadog-instrumentations/src/helpers/hook.js:41:40
    at callHookFn (/project/path/node_modules/import-in-the-middle/index.js:29:22)
    at Hook._iitmHook (/project/path/node_modules/import-in-the-middle/index.js:150:11)
    at /project/path/node_modules/import-in-the-middle/lib/register.js:37:31
    at Array.forEach (<anonymous>)
    at register (/project/path/node_modules/import-in-the-middle/lib/register.js:37:15)
    at file:///project/path/node_modules/vitest/dist/chunks/base.BlXpj3e_.js?iitm=true:122:1
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)

Node.js v20.12.2
```

I am unable to trace why this happens, and thus am unable to create a test case. However, a hooked package resulted in the following `target` and `name` values when I logged it.
```js
console.log(JSON.stringify(target), name) // {} default
```

See https://github.com/DataDog/dd-trace-js/issues/4713#issuecomment-2378371125 for context