### PR TITLE
test: Node v23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - 20.x
           - 21.x
           - 22.x
+          - 23.x
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
Node v23 has `require(esm)` so I wonder whether any of that impacts any of `import-in-the-middle` existing tests...