### PR TITLE
Fix waitForAllMessagesAcknowledged type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,7 +87,7 @@ export declare function removeHook(hookFn: HookFunction): void
 
 type CreateAddHookMessageChannelReturn<Data> = {
   addHookMessagePort: MessagePort,
-  waitForAllMessagesAcknowledged: Promise<void>
+  waitForAllMessagesAcknowledged(): Promise<void>
   registerOptions: { data?: Data; transferList?: any[]; }
 }
 


### PR DESCRIPTION
Error when doing exactly what is says in the docs because of wrong type:

![image](https://github.com/user-attachments/assets/09a7e992-a7d2-43eb-831f-6ed6f8a1f9b7)

It's a function returning a promise, not a promise:

https://github.com/nodejs/import-in-the-middle/blob/ca88f2f59ad8872811d74273283b077160df1531/index.js#L83

This fixes that