### PR TITLE
feat: Warn on multiple hook initialization

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -279,6 +279,12 @@ function createHook (meta) {
   let includeModules, excludeModules
 
   async function initialize (data) {
+    if (global.__import_in_the_middle_initialized__) {
+      console.warn("The 'import-in-the-middle' hook has already been initialized")
+    }
+
+    global.__import_in_the_middle_initialized__ = true
+
     if (data) {
       includeModules = ensureArrayWithBareSpecifiersFileUrlsAndRegex(data.include, 'include')
       excludeModules = ensureArrayWithBareSpecifiersFileUrlsAndRegex(data.exclude, 'exclude')


### PR DESCRIPTION
We've seen cases where users have initialised the `import-in-the-middle` hook more than once. I can't really think of any cases where this is desirable and it's quite difficult to diagnose so it's probably worth displaying a warning.