### PR TITLE
feat: Support absolute paths for `include`

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -2,7 +2,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-const { URL } = require('url')
+const { URL, fileURLToPath } = require('url')
 const { inspect } = require('util')
 const { builtinModules } = require('module')
 const specifiers = new Map()
@@ -341,7 +341,7 @@ function createHook (meta) {
         return each.test(result.url)
       }
 
-      return each === specifier || each === result.url
+      return each === specifier || each === result.url || (result.url.startsWith('file:') && each === fileURLToPath(result.url))
     }
 
     if (includeModules && !includeModules.some(match)) {

--- a/test/fixtures/import-absolute-after.mjs
+++ b/test/fixtures/import-absolute-after.mjs
@@ -1,0 +1,10 @@
+import { strictEqual } from 'assert'
+import * as foo from './foo.mjs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const fooPath = join(dirname(fileURLToPath(import.meta.url)), 'foo.mjs')
+
+strictEqual(typeof foo.foo, 'function')
+strictEqual(global.hooked.length, 1)
+strictEqual(global.hooked[0], fooPath)

--- a/test/fixtures/import-absolute.mjs
+++ b/test/fixtures/import-absolute.mjs
@@ -1,0 +1,18 @@
+import { register } from 'module'
+import { Hook, createAddHookMessageChannel } from '../../index.js'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const fooPath = join(dirname(fileURLToPath(import.meta.url)), 'foo.mjs')
+
+const { registerOptions, waitForAllMessagesAcknowledged } = createAddHookMessageChannel()
+
+register('../../hook.mjs', import.meta.url, registerOptions)
+
+global.hooked = []
+
+Hook([fooPath], (_, name) => {
+  global.hooked.push(name)
+})
+
+await waitForAllMessagesAcknowledged()

--- a/test/register/v18.19-include-message-port-absolute-path.mjs
+++ b/test/register/v18.19-include-message-port-absolute-path.mjs
@@ -1,0 +1,14 @@
+import { spawnSync } from 'child_process'
+
+const out = spawnSync(process.execPath,
+  ['--import', './test/fixtures/import-absolute.mjs', './test/fixtures/import-absolute-after.mjs'],
+  { stdio: 'inherit', env: {} }
+)
+
+if (out.error) {
+  console.error(out.error)
+}
+if (out.status !== 0) {
+  console.error(`Expected exit code 0, got ${out.status}`)
+}
+process.exit(out.status)


### PR DESCRIPTION
`@opentelemetry/instrumentation-aws-lambda` hooks an absolute path but this was not supported by the `include` option. Previously it would have only worked if you passed a file URL when registering the hook.