### PR TITLE
test: skip test when native module is not available

### DIFF
--- a/test/fixtures/native-modules/aix-ppc64.js
+++ b/test/fixtures/native-modules/aix-ppc64.js
@@ -1,0 +1,2 @@
+console.log(`skipping ${process.env.IITM_TEST_FILE} as no native module is available for ${process.platform}-${process.arch}`)
+process.exit(0)

--- a/test/fixtures/native-modules/linux-ppc64.js
+++ b/test/fixtures/native-modules/linux-ppc64.js
@@ -1,0 +1,2 @@
+console.log(`skipping ${process.env.IITM_TEST_FILE} as no native module is available for ${process.platform}-${process.arch}`)
+process.exit(0)

--- a/test/fixtures/native-modules/linux-s390x.js
+++ b/test/fixtures/native-modules/linux-s390x.js
@@ -1,0 +1,2 @@
+console.log(`skipping ${process.env.IITM_TEST_FILE} as no native module is available for ${process.platform}-${process.arch}`)
+process.exit(0)


### PR DESCRIPTION
Skip `test/hook/v14-native-modules.mjs` when no native module is available for the platform.

---

The `@node-rs/crc32-*` module that the test uses [isn't available](https://github.com/napi-rs/node-rs/blob/37e3e833972bde738b055ebaa1ad01a3e4ee2c98/packages/crc32/package.json#L28-L41) on all os-arch combinations.

First noticed in citgm runs, e.g. https://ci.nodejs.org/job/citgm-smoker/nodes=rhel8-s390x/3520/testReport/junit/(root)/citgm/import_in_the_middle_v1_11_3/
```console
 not ok 30 test/hook/v14-native-modules.mjs
   ---
   stdout: ''
   stderr: >-
     node:internal/modules/run_main:104
         triggerUncaughtException(
         ^
     Error: Cannot find module
     '/home/iojs/tmp/citgm_tmp/7285591d-3030-4e14-904d-0a9c0040c0a7/import-in-the-middle/test/fixtures/native-modules/linux-s390x.js'
     imported from
     /home/iojs/tmp/citgm_tmp/7285591d-3030-4e14-904d-0a9c0040c0a7/import-in-the-middle/test/hook/v14-native-modules.mjs
         at finalizeResolution (node:internal/modules/esm/resolve:275:11)
         at moduleResolve (node:internal/modules/esm/resolve:860:10)
         at defaultResolve (node:internal/modules/esm/resolve:984:11)
         at nextResolve (node:internal/modules/esm/hooks:748:28)
         at resolve (/home/iojs/tmp/citgm_tmp/7285591d-3030-4e14-904d-0a9c0040c0a7/import-in-the-middle/hook.js:322:26)
         at nextResolve (node:internal/modules/esm/hooks:748:28)
         at Hooks.resolve (node:internal/modules/esm/hooks:240:30)
         at MessagePort.handleMessage (node:internal/modules/esm/worker:199:24)
         at MessagePort.[nodejs.internal.kHybridDispatch] (node:internal/event_target:827:20)
         at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28) {
       code: 'ERR_MODULE_NOT_FOUND',
       url: 'file:///home/iojs/tmp/citgm_tmp/7285591d-3030-4e14-904d-0a9c0040c0a7/import-in-the-middle/test/fixtures/native-modules/linux-s390x.js'
     }
     Node.js v24.0.0-pre
   ...
```