### PR TITLE
feat: Support import attributes 

### DIFF
--- a/lib/get-esm-exports.js
+++ b/lib/get-esm-exports.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const { Parser } = require('acorn')
-const { importAssertions } = require('acorn-import-attributes')
+const { importAttributesOrAssertions } = require('acorn-import-attributes')
 
 const acornOpts = {
   ecmaVersion: 'latest',
   sourceType: 'module'
 }
 
-const parser = Parser.extend(importAssertions)
+const parser = Parser.extend(importAttributesOrAssertions)
 
 function warn (txt) {
   process.emitWarning(txt, 'get-esm-exports')

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "vue": "^3.4.31"
   },
   "dependencies": {
-    "acorn": "^8.8.2",
+    "acorn": "^8.14.0",
     "acorn-import-attributes": "^1.9.5",
     "cjs-module-lexer": "^1.2.2",
     "module-details-from-path": "^1.0.3"

--- a/test/hook/v20.10-static-import-attributes.mjs
+++ b/test/hook/v20.10-static-import-attributes.mjs
@@ -2,16 +2,14 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
+import Hook from '../../index.js'
 import jsonMjs from '../fixtures/json-attributes.mjs'
 import { strictEqual } from 'assert'
 
-// Acorn does not support import attributes so an error is logged but the import
-// still works!
-//
-// Hook((exports, name) => {
-//   if (name.match(/json\.mjs/)) {
-//     exports.default.data += '-dawg'
-//   }
-// })
+Hook((exports, name) => {
+  if (name.match(/json-attributes\.mjs/)) {
+    exports.default.data += '-dawg'
+  }
+})
 
-strictEqual(jsonMjs.data, 'dog')
+strictEqual(jsonMjs.data, 'dog-dawg')


### PR DESCRIPTION
Bumps the `acorn` version to the latest which now supports import attributes 