### PR TITLE
fix: warning from use of context.importAssertions

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -362,10 +362,8 @@ function createHook (meta) {
     }
 
     // Node.js v21 renames importAssertions to importAttributes
-    if (
-      (context.importAssertions && context.importAssertions.type === 'json') ||
-      (context.importAttributes && context.importAttributes.type === 'json')
-    ) {
+    const importAttributes = context.importAttributes || context.importAssertions
+    if (importAttributes && importAttributes.type === 'json') {
       return result
     }
 


### PR DESCRIPTION
A warning is printed when using context.importAssertions instead of context.importAttributes since Node.js v21.0.0, v20.10.0 and v18.19.0.

Fixes #172