### PR TITLE
test: Pin `openai` test dependency to fix CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "got": "^14.3.0",
     "imhotap": "^2.1.0",
-    "openai": "^4.47.2",
+    "openai": "4.48.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",
     "vue": "^3.4.31"


### PR DESCRIPTION
Because we don't commit the lock file, changing test dependencies can break our tests!