### PR TITLE
fix: handling of circular dependencies

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -253,7 +253,12 @@ async function processModule ({ srcUrl, context, parentGetSource, parentResolve,
       }
     } else {
       addSetter(n, `
-      let $${n} = _.${n}
+      let $${n}
+      try {
+        $${n} = _.${n} = namespace.${n}
+      } catch (err) {
+        if (!(err instanceof ReferenceError)) throw err
+      }
       export { $${n} as ${n} }
       set.${n} = (v) => {
         $${n} = v
@@ -404,10 +409,7 @@ import { register } from '${iitmURL}'
 import * as namespace from ${JSON.stringify(realUrl)}
 
 // Mimic a Module object (https://tc39.es/ecma262/#sec-module-namespace-objects).
-const _ = Object.assign(
-  Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } }),
-  namespace
-)
+const _ = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })
 const set = {}
 const get = {}
 

--- a/test/fixtures/circular-a.mjs
+++ b/test/fixtures/circular-a.mjs
@@ -1,0 +1,5 @@
+import { bar } from './circular-b.mjs'
+
+export const foo = 1
+
+export { bar }

--- a/test/fixtures/circular-b.mjs
+++ b/test/fixtures/circular-b.mjs
@@ -1,0 +1,3 @@
+import { foo } from './circular-a.mjs'
+
+export const bar = foo + 1

--- a/test/register/v18.19-circular.mjs
+++ b/test/register/v18.19-circular.mjs
@@ -1,0 +1,17 @@
+import { register } from 'module'
+import Hook from '../../index.js'
+import { strictEqual } from 'assert'
+
+register('../../hook.mjs', import.meta.url)
+
+let bar
+
+Hook((exports, name) => {
+  if (name.match(/circular-b.mjs/)) {
+    bar = exports.bar
+  }
+})
+
+await import('../fixtures/circular-b.mjs')
+
+strictEqual(bar, 2)


### PR DESCRIPTION
Fixes #163

In the integration CI, this fixes importing the svelte package.

It does not result in identical behavior to Node.js, but this is very much a corner case:

```javascript
// Importing 'a' first will fail in Node.js (with or without the loader)
await import('./test/fixtures/circular-a.mjs')
await import('./test/fixtures/circular-b.mjs')
```

```javascript
// If you try and ignore the error
try { await import('./test/fixtures/circular-a.mjs') } catch { }
// it affects the subsequent import of 'b', which will now fail
await import('./test/fixtures/circular-b.mjs')
```

```javascript
// If 'b' is imported first, it succeeds (as in the test case)
await import('./test/fixtures/circular-b.mjs')
// If the import of 'a' is done after, it also succeeds with { foo: 1, bar: 2 }
// With this PR, we return { foo: 1, bar: undefined }
await import('./test/fixtures/circular-a.mjs')
// Given that importing 'a' directly is fragile, it's likely
// not imported directly in real-world scenarios but rather through 'b'
```