### PR TITLE
fix: Hook internal paths like `require-in-the-middle`

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,8 +143,6 @@ function Hook (modules, options, hookFn) {
           if (baseDir) {
             if (internals) {
               name = name + path.sep + path.relative(baseDir, fileURLToPath(filename))
-            } else {
-              if (!baseDir.endsWith(specifiers.get(filename))) continue
             }
           }
           callHookFn(hookFn, namespace, name, baseDir)

--- a/test/hook/static-import-package-internals.mjs
+++ b/test/hook/static-import-package-internals.mjs
@@ -2,7 +2,7 @@ import Hook from '../../index.js'
 import { Report } from 'c8/index.js'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { strictEqual, notStrictEqual } from 'assert'
+import { strictEqual } from 'assert'
 
 const c8Dir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'node_modules', 'c8')
 
@@ -12,4 +12,4 @@ Hook(['c8'], (exports, name, baseDir) => {
   exports.Report = () => 42
 })
 
-notStrictEqual(Report({}), 42)
+strictEqual(Report({}), 42)


### PR DESCRIPTION
- Closes #185 
- Closes #187

`import-in-the-middle` differs from `require-in-the-middle` in that you can't patch library internals. Open Telemetry expects these libraries to behave in the same way so you can patch a library with the same hook configuration. 

- This is not technically breaking if `import-in-the-middle` was not behaving as intended and documented
- This could result in the `Hook` callbacks being called a lot more, for all internal files