### PR TITLE
test: Pin openai version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "got": "^14.3.0",
     "imhotap": "^2.1.0",
-    "openai": "^4.47.2",
+    "openai": "4.47.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",
     "vue": "^3.4.31"


### PR DESCRIPTION
`openai` has lots of churn and it takes quite a lot of effort to keep our CI passing.

This PR pins the version so we are still testing the behaviour it was originally added as a dependency for. We are no longer tested any breaking changes it might introduce. 