### PR TITLE
feat: Optionally hook internal paths like `require-in-the-middle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ fs.readFileSync('file.txt')
 node --import=./instrument.mjs ./my-app.mjs
 ```
 
+### Experimental `experimentalPatchInternals` option
+
+It was found that `import-in-the-middle` didn't match the hooking behavior of `require-in-the-middle` in some cases: 
+https://github.com/nodejs/import-in-the-middle/issues/185
+
+The `experimentalPatchInternals` option forces the loader to match the behavior of `require-in-the-middle` in these cases.
+
+This option is experimental and may be removed or made the default in the future.
+
+```js
+import { register } from 'module'
+
+register('import-in-the-middle/hook.mjs', import.meta.url, {
+  data: { experimentalPatchInternals: true }
+})
+```
+
 ## Limitations
 
 * You cannot add new exports to a module. You can only modify existing ones.

--- a/hook.js
+++ b/hook.js
@@ -7,6 +7,7 @@ const { inspect } = require('util')
 const { builtinModules } = require('module')
 const specifiers = new Map()
 const isWin = process.platform === 'win32'
+let experimentalPatchInternals = false
 
 // FIXME: Typescript extensions are added temporarily until we find a better
 // way of supporting arbitrary extensions
@@ -292,6 +293,10 @@ function createHook (meta) {
     global.__import_in_the_middle_initialized__ = true
 
     if (data) {
+      if (data.experimentalPatchInternals) {
+        experimentalPatchInternals = true
+      }
+
       includeModules = ensureArrayWithBareSpecifiersFileUrlsAndRegex(data.include, 'include')
       excludeModules = ensureArrayWithBareSpecifiersFileUrlsAndRegex(data.exclude, 'exclude')
 
@@ -410,6 +415,7 @@ function createHook (meta) {
           source: `
 import { register } from '${iitmURL}'
 import * as namespace from ${JSON.stringify(realUrl)}
+${experimentalPatchInternals ? `import { setExperimentalPatchInternals } from '${iitmURL}'\nsetExperimentalPatchInternals(true)` : ''}
 
 // Mimic a Module object (https://tc39.es/ecma262/#sec-module-namespace-objects).
 const _ = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ const { MessageChannel } = require('worker_threads')
 const {
   importHooks,
   specifiers,
-  toHook
+  toHook,
+  getExperimentalPatchInternals
 } = require('./lib/register')
 
 function addHook (hook) {
@@ -144,7 +145,7 @@ function Hook (modules, options, hookFn) {
             if (internals) {
               name = name + path.sep + path.relative(baseDir, fileURLToPath(filename))
             } else {
-              if (!baseDir.endsWith(specifiers.get(filename))) continue
+              if (!getExperimentalPatchInternals() && !baseDir.endsWith(specifiers.get(filename))) continue
             }
           }
           callHookFn(hookFn, namespace, name, baseDir)

--- a/lib/register.js
+++ b/lib/register.js
@@ -43,7 +43,19 @@ function register (name, namespace, set, get, specifier) {
   toHook.push([name, proxy])
 }
 
+let experimentalPatchInternals = false
+
+function getExperimentalPatchInternals () {
+  return experimentalPatchInternals
+}
+
+function setExperimentalPatchInternals (value) {
+  experimentalPatchInternals = value
+}
+
 exports.register = register
 exports.importHooks = importHooks
 exports.specifiers = specifiers
 exports.toHook = toHook
+exports.getExperimentalPatchInternals = getExperimentalPatchInternals
+exports.setExperimentalPatchInternals = setExperimentalPatchInternals

--- a/test/register/v18.19-experimental-patch-internals.mjs
+++ b/test/register/v18.19-experimental-patch-internals.mjs
@@ -1,0 +1,14 @@
+import { register } from 'module'
+import Hook from '../../index.js'
+import { strictEqual } from 'assert'
+
+register('../../hook.mjs', import.meta.url, { data: { experimentalPatchInternals: true } })
+
+Hook(['c8'], (exports, name) => {
+  strictEqual(name, 'c8')
+  exports.Report = () => 42
+})
+
+const { Report } = await import('c8/index.js')
+
+strictEqual(Report({}), 42)


### PR DESCRIPTION
As discussed in the Diagnostics Working Group meeting, this PR is similar to #189 but allows this change to be selectively enabled so it can be tested more thoroughly before becoming the default.

Sentry are happy to do this testing!