### PR TITLE
fix: Account for invalid identifiers

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -254,19 +254,22 @@ async function processModule ({ srcUrl, context, parentGetSource, parentResolve,
         addSetter(name, setter, true)
       }
     } else {
+      const variableName = `$${n.replace(/[^a-zA-Z0-9_]/g, '_')}`
+      const objectKey = JSON.stringify(n)
+
       addSetter(n, `
-      let $${n}
+      let ${variableName}
       try {
-        $${n} = _.${n} = namespace.${n}
+        ${variableName} = _[${objectKey}] = namespace[${objectKey}]
       } catch (err) {
         if (!(err instanceof ReferenceError)) throw err
       }
-      export { $${n} as ${n} }
-      set.${n} = (v) => {
-        $${n} = v
+      export { ${variableName} as ${objectKey} }
+      set[${objectKey}] = (v) => {
+        ${variableName} = v
         return true
       }
-      get.${n} = () => $${n}
+      get[${objectKey}] = () => ${variableName}
       `)
     }
   }

--- a/test/fixtures/invalid-identifier.js
+++ b/test/fixtures/invalid-identifier.js
@@ -1,0 +1,5 @@
+// These export identifiers are only supported in Node 16+
+exports['one.two'] = () => console.log('b')
+
+// See: https://github.com/nodejs/import-in-the-middle/issues/94
+exports['unsigned short'] = 'something'

--- a/test/fixtures/module-exports-cjs-shim.mjs
+++ b/test/fixtures/module-exports-cjs-shim.mjs
@@ -1,0 +1,7 @@
+// Regression test for https://github.com/nodejs/import-in-the-middle/issues/196
+
+export default function foo () {
+  // do nothing
+}
+
+export { foo as 'module.exports' }

--- a/test/hook/v16-fake-cjs-export.mjs
+++ b/test/hook/v16-fake-cjs-export.mjs
@@ -1,0 +1,4 @@
+import ui from '../fixtures/module-exports-cjs-shim.mjs'
+import { notStrictEqual } from 'assert'
+
+notStrictEqual(ui, undefined)

--- a/test/hook/v16-invalid-identifier.mjs
+++ b/test/hook/v16-invalid-identifier.mjs
@@ -1,0 +1,5 @@
+import * as lib from '../fixtures/invalid-identifier.js'
+import { strictEqual } from 'assert'
+
+strictEqual(typeof lib['one.two'], 'function')
+strictEqual(typeof lib['unsigned short'], 'string')


### PR DESCRIPTION
Node 16 and above allows you to use interesting string identifiers like `"module.exports"` and `"unsigned short"` as valid export names.

ref https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export

<img width="789" alt="image" src="https://github.com/user-attachments/assets/26658c8e-f92e-494a-8aea-be78e5b88ff9" />

This PR accounts for that by updating our shim variable name logic, and adjusting how we do getters and setters so that we don't break when encoutering these "invalid" identifiers.

supercedes https://github.com/nodejs/import-in-the-middle/pull/115
resolves https://github.com/nodejs/import-in-the-middle/issues/94

If you can, please give this a test locally. I tried it myself on some test apps and worked fine.