### PR TITLE
fix: do not replace dollar sign in shim variable name

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -254,7 +254,7 @@ async function processModule ({ srcUrl, context, parentGetSource, parentResolve,
         addSetter(name, setter, true)
       }
     } else {
-      const variableName = `$${n.replace(/[^a-zA-Z0-9_]/g, '_')}`
+      const variableName = `$${n.replace(/[^a-zA-Z0-9_$]/g, '_')}`
       const objectKey = JSON.stringify(n)
       const reExportedName = n === 'default' || NODE_MAJOR < 16 ? n : objectKey
 

--- a/test/fixtures/invalid-identifier.js
+++ b/test/fixtures/invalid-identifier.js
@@ -3,3 +3,6 @@ exports['one.two'] = () => console.log('b')
 
 // See: https://github.com/nodejs/import-in-the-middle/issues/94
 exports['unsigned short'] = 'something'
+
+exports._ = 'foo'
+exports.$ = 'bar'


### PR DESCRIPTION
With the change in #198 both `$` and `_` will be mapped to `$_`. If both of those names are used, there will be an error like this:

```
SyntaxError: Identifier '$_' has already been declared
        at compileSourceTextModule (node:internal/modules/esm/utils:344:16)
        at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:105:18)
        at #translate (node:internal/modules/esm/loader:534:12)
        at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:581:27)
```

This change updates the regex to not replace `$` as it should also be valid in identifiers. 