### PR TITLE
chore: setup npm OIDC for publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -29,5 +33,3 @@ jobs:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- [x] Created npm OIDC on repo `nodejs/import-in-the-middle` with workflow file `release-please.yml`.

Refs: https://github.com/nodejs/admin/issues/998