### PR TITLE
chore: use npm@11 for OIDC publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,4 +32,5 @@ jobs:
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@11
       - run: npm publish --access public


### PR DESCRIPTION
OIDC support is only available in npm >=11.5.1

Refs: https://github.com/nodejs/import-in-the-middle/pull/203
Refs: https://github.com/nodejs/admin/issues/998