### PR TITLE
fix: use `createRequire` to load `hook.js`

### DIFF
--- a/hook.mjs
+++ b/hook.mjs
@@ -2,7 +2,9 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-import { createHook } from './hook.js'
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const { createHook } = require('./hook.js')
 
 const { initialize, load, resolve, getFormat, getSource } = createHook(import.meta)
 

--- a/test/fixtures/double-loader.mjs
+++ b/test/fixtures/double-loader.mjs
@@ -1,0 +1,9 @@
+import { readFile } from 'fs/promises'
+
+export async function load (url, context, nextLoad) {
+  const result = await nextLoad(url, context)
+  if (!result.source && url.startsWith('file:')) {
+    result.source = await readFile(new URL(url))
+  }
+  return result
+}

--- a/test/other/double-loading.mjs
+++ b/test/other/double-loading.mjs
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+import { execSync } from 'child_process'
+import { doesNotThrow } from 'assert'
+
+const env = {
+  ...process.env,
+  NODE_OPTIONS: '--no-warnings --experimental-loader ./test/fixtures/double-loader.mjs --experimental-loader ./hook.mjs'
+}
+
+doesNotThrow(() => {
+  execSync('node -p 0', { env })
+})


### PR DESCRIPTION
If import is used to load hook.js, then any additional loaders running before IITM that assign `result.source` (as indicated by the Node.js docs) on CommonJS files will cause a not-implemented error to be thrown inside Node.js. This is probably a bug in Node.js, but this ought to be an appropriate workaround (espectially since IITM supports old versions of Node.js).

Here is a reproduction without using IITM: https://gist.github.com/bengl/75470adfc01e83886572132ab1ce7af4

An issue will be opened on Node.js core soon.