### PR TITLE
fix: `@vercel/nft` resolving `createRequire`

### DIFF
--- a/hook.mjs
+++ b/hook.mjs
@@ -2,8 +2,9 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-import { createRequire } from 'node:module'
-const require = createRequire(import.meta.url)
+import * as module from 'node:module'
+
+const require = module.createRequire(import.meta.url)
 const { createHook } = require('./hook.js')
 
 const { initialize, load, resolve, getFormat, getSource } = createHook(import.meta)

--- a/hook.mjs
+++ b/hook.mjs
@@ -4,6 +4,8 @@
 
 import * as module from 'node:module'
 
+// Using 'module.createRequire' is key for this to be resolved by @vercel/nft:
+// https://github.com/vercel/nft/pull/459/files#diff-f9de9e832021754e4f7e493614502e6a12c6adf1d75f666ffdf9c2b8de8d33bcR1090
 const require = module.createRequire(import.meta.url)
 const { createHook } = require('./hook.js')
 


### PR DESCRIPTION
This PR changed the ESM code to use `createRequire` to load the CJS hook:
- #205

`@vercel/nft` is used by some frameworks to determine which dependency files should be included in production without doing any bundling.

Unfortunately it looks like their support for `createRequire` requires that it is accessed on a variable called `module`:
- https://github.com/vercel/nft/pull/459/files#diff-f9de9e832021754e4f7e493614502e6a12c6adf1d75f666ffdf9c2b8de8d33bcR1090

