### PR TITLE
test: Make "cjs" test fixture actually commonjs

### DIFF
--- a/test/fixtures/node_modules/@scope/some-scoped-cjs-module/index.js
+++ b/test/fixtures/node_modules/@scope/some-scoped-cjs-module/index.js
@@ -1,1 +1,1 @@
-export const foo = 'bar'
+exports.foo = 'bar'

--- a/test/fixtures/node_modules/@scope/some-scoped-cjs-module/package.json
+++ b/test/fixtures/node_modules/@scope/some-scoped-cjs-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scope/some-scoped-cjs-module",
-  "type": "module",
+  "type": "commonjs",
   "exports": {
     ".": "./index.js",
     "./sub": "./sub.js"

--- a/test/fixtures/node_modules/@scope/some-scoped-cjs-module/sub.js
+++ b/test/fixtures/node_modules/@scope/some-scoped-cjs-module/sub.js
@@ -1,1 +1,1 @@
-export const bar = 'baz'
+exports.bar = 'baz'


### PR DESCRIPTION
Correct an oversight in the test fixtures added for the fix in a20f47a3013105a235f2ba48bc17319f7a57636c. The test passes fine whether the module is commonjs or esm, which is the point, but it was not actually testing the commonjs case as intended.

Make the package.json no longer define it as `"type": "module"` and convert the package modules to commonjs export format.

cc: @trentm 