### PR TITLE
fix: properly handle internals when specifier matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,14 +140,16 @@ function Hook (modules, options, hookFn) {
 
     if (modules) {
       for (const moduleName of modules) {
-        if (moduleName === specifier) {
-          callHookFn(hookFn, namespace, name, baseDir)
-        } else if (moduleName === name) {
+        const nameMatch = moduleName === name
+        const specMatch = moduleName === specifier
+        if (nameMatch || specMatch) {
           if (baseDir) {
             if (internals) {
               name = name + path.sep + path.relative(baseDir, fileURLToPath(filename))
             } else {
-              if (!getExperimentalPatchInternals() && !baseDir.endsWith(specifiers.get(filename))) continue
+              if (!getExperimentalPatchInternals() && !specMatch && !baseDir.endsWith(specifiers.get(filename))) {
+                continue
+              }
             }
           }
           callHookFn(hookFn, namespace, name, baseDir)

--- a/test/low-level/v22-esm-internal-spec-match.mjs
+++ b/test/low-level/v22-esm-internal-spec-match.mjs
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+import { createAddHookMessageChannel, Hook } from '../../index.js'
+import { register } from 'module'
+import { fileURLToPath, pathToFileURL } from 'url'
+import { dirname, resolve } from 'path'
+import { equal, deepStrictEqual } from 'assert'
+
+import test from 'node:test'
+
+const {
+  registerOptions,
+  waitForAllMessagesAcknowledged
+} = createAddHookMessageChannel()
+
+const hookModuleURL = String(pathToFileURL(
+  resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../hook.mjs'
+  )
+))
+
+register(hookModuleURL, import.meta.url, registerOptions)
+
+Hook(['some-external-module'], { internals: true }, (exported, name) => {
+  equal(name, 'some-external-module/index.mjs')
+  exported.foo += '-mutated'
+})
+
+Hook(['some-external-cjs-module'], { internals: true }, (exported, name) => {
+  equal(name, 'some-external-cjs-module/index.js')
+  exported.foo += '-mutated (cjs)'
+})
+
+Hook(['@scope/some-scoped-module'], { internals: true }, (exported, name) => {
+  equal(name, '@scope/some-scoped-module/index.mjs')
+  exported.foo += '-mutated'
+})
+
+Hook(['@scope/some-scoped-cjs-module'], { internals: true }, (exported, name) => {
+  equal(name, '@scope/some-scoped-cjs-module/index.js')
+  exported.foo += '-mutated (cjs)'
+})
+
+Hook(['some-external-module'], { internals: false }, (_, name) => {
+  equal(name, 'some-external-module')
+})
+
+Hook(['some-external-cjs-module'], { internals: false }, (_, name) => {
+  equal(name, 'some-external-cjs-module')
+})
+
+Hook(['@scope/some-scoped-module'], { internals: false }, (_, name) => {
+  equal(name, '@scope/some-scoped-module')
+})
+
+Hook(['@scope/some-scoped-cjs-module'], { internals: false }, (_, name) => {
+  equal(name, '@scope/some-scoped-cjs-module')
+})
+
+await waitForAllMessagesAcknowledged()
+
+test('loading hooked modules and submodules', async () => {
+  const results = await import('../fixtures/load-external-modules.mjs')
+  const expect = {
+    scoped: 'bar-mutated',
+    scopedsub: 'baz',
+    scopedCJS: 'bar-mutated (cjs)',
+    scopedCJSsub: 'baz',
+    unscoped: 'bar-mutated',
+    unscopedsub: 'baz',
+    unscopedCJS: 'bar-mutated (cjs)',
+    unscopedCJSsub: 'baz'
+  }
+
+  deepStrictEqual(Object.assign({}, results), expect)
+})


### PR DESCRIPTION
The fix in a20f47a had the unfortunate side effect of skipping the proper handling of `internals: true` hooks when the specifier was an exact match to the the module name being loaded.

This resulted in breaking the dd-trace vitest integration.

cc: @BridgeAR 

re: https://github.com/nodejs/import-in-the-middle/pull/215#issuecomment-3676374553