### PR TITLE
fix: do not crash on missing setters

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,12 @@ function removeHook (hook) {
 function callHookFn (hookFn, namespace, name, baseDir) {
   const newDefault = hookFn(namespace, name, baseDir)
   if (newDefault && newDefault !== namespace) {
-    namespace.default = newDefault
+    // Only ESM modules that actually export `default` can have it reassigned.
+    // Some hooks return a value unconditionally; avoid crashing when the module
+    // has no default export (see issue #188).
+    if ('default' in namespace) {
+      namespace.default = newDefault
+    }
   }
 }
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -10,7 +10,14 @@ const toHook = []
 
 const proxyHandler = {
   set (target, name, value) {
-    return setters.get(target)[name](value)
+    const set = setters.get(target)
+    const setter = set && set[name]
+    if (typeof setter === 'function') {
+      return setter(value)
+    }
+    // If a module doesn't export the property being assigned (e.g. no default
+    // export), there is no setter to call. Don't crash userland code.
+    return true
   },
 
   get (target, name) {
@@ -30,7 +37,12 @@ const proxyHandler = {
       throw new Error('Getters/setters are not supported for exports property descriptors.')
     }
 
-    return setters.get(target)[property](descriptor.value)
+    const set = setters.get(target)
+    const setter = set && set[property]
+    if (typeof setter === 'function') {
+      return setter(descriptor.value)
+    }
+    return true
   }
 }
 

--- a/test/hook/static-import-no-default.mjs
+++ b/test/hook/static-import-no-default.mjs
@@ -1,0 +1,17 @@
+import { Hook } from '../../index.js'
+import { strictEqual } from 'assert'
+
+// If a module does not export `default`, returning a "new default" from the hook
+// should not crash (see issue #188).
+Hook((exports, name) => {
+  if (name.match(/foo\.mjs/)) {
+    return function newDefault () {
+      return 'should-not-be-applied'
+    }
+  }
+})
+
+import * as ns from '../fixtures/foo.mjs'
+
+strictEqual('default' in ns, false)
+strictEqual(ns.foo(), 'foo')


### PR DESCRIPTION
Fixes: https://github.com/nodejs/import-in-the-middle/issues/188