### PR TITLE
Fix entrypoint can be treated as CommonJS when loader chains add query params to file URLs

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -381,7 +381,7 @@ export function createHook (meta) {
     // "main" module (e.g. require.main === module). Wrapping changes how they
     // are evaluated, and can make them exit without doing anything.
     if (parentURL === '') {
-      if (!EXTENSION_RE.test(result.url)) {
+      if (!EXTENSION_RE.test(result.url) && !hasIitm(result.url)) {
         entrypoint = result.url
         return { url: result.url, format: 'commonjs' }
       }

--- a/test/fixtures/entrypoint-iitm-query-loader.mjs
+++ b/test/fixtures/entrypoint-iitm-query-loader.mjs
@@ -1,0 +1,20 @@
+import { createHook } from '../../create-hook.mjs'
+
+const { resolve } = createHook(import.meta)
+
+export async function resolveHook (specifier, context, nextResolve) {
+  if (!context.parentURL) {
+    const base = await nextResolve(specifier, context)
+    const url = new URL(base.url)
+    url.searchParams.set('iitm', 'true')
+    const tagged = { ...base, url: url.href }
+    const result = await resolve(url.href, context, async () => tagged)
+    if (result.format === 'commonjs') {
+      throw new Error('entrypoint resolved as commonjs')
+    }
+    return result
+  }
+  return resolve(specifier, context, nextResolve)
+}
+
+export { resolveHook as resolve }

--- a/test/fixtures/entrypoint-query.mjs
+++ b/test/fixtures/entrypoint-query.mjs
@@ -1,0 +1,2 @@
+export const ok = true
+console.log('entry ok')

--- a/test/other/entrypoint-query.mjs
+++ b/test/other/entrypoint-query.mjs
@@ -1,0 +1,11 @@
+import { execSync } from 'child_process'
+import { doesNotThrow } from 'assert'
+
+const env = {
+  ...process.env,
+  NODE_OPTIONS: '--no-warnings --experimental-loader ./test/fixtures/entrypoint-iitm-query-loader.mjs'
+}
+
+doesNotThrow(() => {
+  execSync('node ./test/fixtures/entrypoint-query.mjs', { env })
+})


### PR DESCRIPTION
Fixes #232 