### PR TITLE
fix: Updated proxying logic for builtins that are used as CJS

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -423,7 +423,11 @@ export function createHook (meta) {
     // When a CJS module is loaded by an IITM shim, its require() calls for
     // builtins may be routed through the ESM resolver on Node 24+. Skip IITM
     // wrapping in that case so require() returns the native module value.
+    // We also propagate the membership to the resolved child so that its own
+    // transitive require() calls are likewise skipped (the entire synchronous
+    // CJS require chain must remain unwrapped to avoid ERR_VM_MODULE_LINK_FAILURE).
     if (cjsInIitmChain.has(parentURL)) {
+      cjsInIitmChain.add(result.url)
       return result
     }
 
@@ -588,6 +592,24 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
 
       // Fall back to the parent loader with the original (non-iitm) URL.
       return parentLoad(deleteIitm(url), context)
+    }
+
+    // On Node 22+, when a CJS module is loaded through the ESM translator and
+    // another loader hook provides its source (instead of leaving source null
+    // for Node to read natively), require() calls inside that CJS module for
+    // packages using the "module-sync" exports condition fail with
+    // ERR_VM_MODULE_LINK_FAILURE. Work around this Node bug by stripping
+    // hook-provided source for CJS modules in the synchronous require chain,
+    // forcing Node to use its native CJS loader which handles this correctly.
+    if (cjsInIitmChain.has(url)) {
+      const result = await parentLoad(url, context)
+      if (result.format === 'commonjs' && result.source != null) {
+        return {
+          format: result.format,
+          source: undefined
+        }
+      }
+      return result
     }
 
     return parentLoad(url, context)

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -265,12 +265,19 @@ async function processModule ({ srcUrl, context, parentGetSource, parentResolve,
       const objectKey = JSON.stringify(n)
       const reExportedName = n === 'default' ? n : objectKey
 
+      // For the module.exports synthetic export (Node 23+), fall back to $default
+      // when namespace['module.exports'] is not exposed by the native ESM namespace
+      // (builtins don't expose it). This ensures the IITM hook proxy returns the
+      // actual CJS value (e.g. EventEmitter) when an instrumentor reads
+      // capturedExports['module.exports'], rather than undefined.
+      const moduleExportsFallback = n === 'module.exports' ? ' ?? $default' : ''
+
       addSetter(n, `
       let ${variableName}
       __overridden[${objectKey}] = false
       let ${variableName}Defer = false
       try {
-        ${variableName} = _[${objectKey}] = namespace[${objectKey}]
+        ${variableName} = _[${objectKey}] = namespace[${objectKey}]${moduleExportsFallback}
       } catch (err) {
         if (!(err instanceof ReferenceError)) throw err
         ${variableName}Defer = true
@@ -279,11 +286,11 @@ async function processModule ({ srcUrl, context, parentGetSource, parentResolve,
       if (${variableName}Defer || ${variableName} === undefined) {
         __pending.push(__makeUpdater(
           ${objectKey},
-          () => namespace[${objectKey}],
+          () => namespace[${objectKey}]${moduleExportsFallback},
           (v) => { ${variableName} = _[${objectKey}] = v }
         ))
       }
-      export { ${variableName} as ${reExportedName} }
+      ${(n === 'module.exports' && (srcUrl.startsWith('node:') || builtinModules.includes(srcUrl))) ? '' : `export { ${variableName} as ${reExportedName} }`}
       set[${objectKey}] = (v) => {
         __overridden[${objectKey}] = true
         ${variableName} = v
@@ -307,6 +314,14 @@ export function createHook (meta) {
   let cachedResolve
   const iitmURL = new URL('lib/register.js', meta.url).toString()
   let includeModules, excludeModules
+
+  // Track CJS module URLs that IITM has wrapped. On Node 24+, CJS modules loaded
+  // via loadCJSModule (in an ESM import chain) have their require() calls for
+  // builtins routed through the ESM resolver. Without this guard, IITM would
+  // intercept those require() calls and return an ESM namespace object instead
+  // of the native CJS module value (e.g. EventEmitter constructor), breaking
+  // patterns like `class App extends require('events') {}`.
+  const cjsInIitmChain = new Set()
 
   async function initialize (data) {
     if (global.__import_in_the_middle_initialized__) {
@@ -405,6 +420,13 @@ export function createHook (meta) {
       return result
     }
 
+    // When a CJS module is loaded by an IITM shim, its require() calls for
+    // builtins may be routed through the ESM resolver on Node 24+. Skip IITM
+    // wrapping in that case so require() returns the native module value.
+    if (cjsInIitmChain.has(parentURL)) {
+      return result
+    }
+
     // We don't want to attempt to wrap native modules
     if (result.url.endsWith('.node')) {
       return result
@@ -448,6 +470,11 @@ export function createHook (meta) {
         })
         // If the module loaded successfully, we can remove the specifier to reduce memory usage early.
         specifiers.delete(realUrl)
+        // Track CJS modules so their transitive require() calls bypass IITM.
+        // context.format is set to 'commonjs' by getCjsExports during processModule.
+        if (context.format === 'commonjs') {
+          cjsInIitmChain.add(realUrl)
+        }
         return {
           source: `
 import { register } from '${iitmURL}'

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -150,7 +150,12 @@ function getExportsForNodeBuiltIn (name) {
   }
 
   if (!exports) {
-    exports = new Set(addDefault(Object.keys(require(name))))
+    // get all properties both enumerable and non-enumerable
+    exports = new Set(addDefault(Object.getOwnPropertyNames(require(name))))
+    // added in node 23 as alias for default in cjs modules
+    if (hasModuleExportsCJSDefault) {
+      exports.add('module.exports')
+    }
     BUILT_INS.set(name, exports)
   }
 

--- a/test/fixtures/cjs-extends-events.js
+++ b/test/fixtures/cjs-extends-events.js
@@ -1,0 +1,5 @@
+// Fixture for testing that CJS require('node:events') still returns a usable
+// constructor when IITM has wrapped node:events. Used by the v22+ test for
+// the module.exports shim fallback.
+const EventEmitter = require('node:events')
+module.exports = class Foo extends EventEmitter {}

--- a/test/fixtures/cjs-requires-module-sync.js
+++ b/test/fixtures/cjs-requires-module-sync.js
@@ -1,0 +1,9 @@
+// CJS module that require()s a package with a "module-sync" exports condition.
+// On Node 22+, require() resolves to the ESM wrapper (require.mjs), which
+// imports ./index.js. If hook-provided source is not stripped for CJS modules
+// in the synchronous require chain, ModuleJob.runSync fails with
+// ERR_VM_MODULE_LINK_FAILURE.
+const pkg = require('module-sync-fixture')
+// When loaded via module-sync condition, pkg is the default export (a string).
+// When loaded via CJS default, pkg is { value: 'from-cjs' }.
+module.exports.result = typeof pkg === 'string' ? pkg : (pkg.value ?? pkg.default)

--- a/test/fixtures/cjs-transitive-a.js
+++ b/test/fixtures/cjs-transitive-a.js
@@ -1,0 +1,6 @@
+// Top-level CJS module — requires cjs-transitive-b.js.
+// This simulates koa requiring is-generator-function.
+const b = require('./cjs-transitive-b.js')
+module.exports.fromB = b.own
+module.exports.fromC = b.fromC
+module.exports.own = 'top'

--- a/test/fixtures/cjs-transitive-b.js
+++ b/test/fixtures/cjs-transitive-b.js
@@ -1,0 +1,5 @@
+// Middle CJS module — requires cjs-transitive-c.js.
+// This simulates is-generator-function requiring has-tostringtag.
+const c = require('./cjs-transitive-c.js')
+module.exports.fromC = c.value
+module.exports.own = 'middle'

--- a/test/fixtures/cjs-transitive-c.js
+++ b/test/fixtures/cjs-transitive-c.js
@@ -1,0 +1,5 @@
+// Deepest CJS module in the transitive require chain.
+// If IITM wraps this module, the generated shim will try to
+// `import { register } from '...'` which fails under synchronous
+// ModuleJob.runSync with ERR_VM_MODULE_LINK_FAILURE.
+module.exports.value = 'deep'

--- a/test/fixtures/node_modules/module-sync-fixture/index.js
+++ b/test/fixtures/node_modules/module-sync-fixture/index.js
@@ -1,0 +1,2 @@
+// CJS implementation
+module.exports.value = 'from-cjs'

--- a/test/fixtures/node_modules/module-sync-fixture/index.mjs
+++ b/test/fixtures/node_modules/module-sync-fixture/index.mjs
@@ -1,0 +1,3 @@
+import { value } from './index.js'
+export default value
+export { value }

--- a/test/fixtures/node_modules/module-sync-fixture/package.json
+++ b/test/fixtures/node_modules/module-sync-fixture/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "module-sync-fixture",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "module-sync": "./require.mjs",
+      "import": "./index.mjs",
+      "default": "./index.js"
+    }
+  }
+}

--- a/test/fixtures/node_modules/module-sync-fixture/require.mjs
+++ b/test/fixtures/node_modules/module-sync-fixture/require.mjs
@@ -1,0 +1,8 @@
+// ESM wrapper used by the "module-sync" condition when require() loads this package.
+// This imports the CJS implementation — if the dependency can't be linked
+// synchronously (due to hook-provided source on the parent CJS module),
+// ERR_VM_MODULE_LINK_FAILURE occurs.
+import { value } from './index.js'
+const result = value + '-via-module-sync'
+export default result
+export { result as value, result as 'module.exports' }

--- a/test/fixtures/register-iitm-with-source-hook.mjs
+++ b/test/fixtures/register-iitm-with-source-hook.mjs
@@ -1,0 +1,10 @@
+// source-providing-hook first (innermost), then IITM (outermost).
+// This ensures IITM can intercept and strip hook-provided source for CJS
+// modules in the synchronous require chain.
+import { register } from 'module'
+
+// Inner hook: provides source for CJS modules (mimics @apm-js-collab/tracing-hooks)
+register(new URL('./source-providing-hook.mjs', import.meta.url).href, import.meta.url)
+
+// Outer hook: IITM
+register(new URL('../../hook.mjs', import.meta.url).href, import.meta.url)

--- a/test/fixtures/source-providing-hook.mjs
+++ b/test/fixtures/source-providing-hook.mjs
@@ -1,0 +1,17 @@
+// A minimal loader hook that provides source for CJS modules.
+// This mimics the behavior of @apm-js-collab/tracing-hooks which reads and
+// potentially transforms CJS source. On Node 22+, providing source for CJS
+// modules via hooks changes the require() behavior inside those modules,
+// breaking require() of packages with "module-sync" exports conditions.
+import { readFile } from 'node:fs/promises'
+
+export async function load (url, context, nextLoad) {
+  const result = await nextLoad(url, context)
+  if (result.format === 'commonjs' && result.source == null && url.startsWith('file:')) {
+    try {
+      const parsedUrl = new URL(result.responseURL ?? url)
+      result.source = await readFile(parsedUrl)
+    } catch {}
+  }
+  return result
+}

--- a/test/get-esm-exports/get-exports-builtin-non-enumerable.mjs
+++ b/test/get-esm-exports/get-exports-builtin-non-enumerable.mjs
@@ -1,0 +1,30 @@
+import { strictEqual, ok } from 'assert'
+import { getExports, hasModuleExportsCJSDefault } from '../../lib/get-exports.mjs'
+
+// getExports should use Object.getOwnPropertyNames (not Object.keys) so that
+// non-enumerable properties of Node built-in modules are included.
+// fs.F_OK, R_OK, W_OK, X_OK are non-enumerable on require('fs') but are
+// real exports that should be discoverable.
+const mockParentLoad = async () => ({ source: null, format: 'builtin' })
+
+const exports = await getExports('node:fs', { format: 'builtin' }, mockParentLoad)
+
+ok(exports.has('F_OK'), 'F_OK (non-enumerable on require("fs")) should be in exports')
+ok(exports.has('R_OK'), 'R_OK should be in exports')
+ok(exports.has('W_OK'), 'W_OK should be in exports')
+ok(exports.has('X_OK'), 'X_OK should be in exports')
+
+// Sanity check: enumerable exports should still be present
+ok(exports.has('readFile'), 'readFile should be in exports')
+ok(exports.has('default'), 'default should be in exports')
+
+// Node >= 23 adds `module.exports` as an alias for the default export in CJS modules
+if (hasModuleExportsCJSDefault) {
+  ok(exports.has('module.exports'), 'module.exports should be in exports on Node >= 23')
+} else {
+  ok(!exports.has('module.exports'), 'module.exports should not be in exports on Node < 23')
+}
+
+strictEqual(typeof exports.has, 'function', 'getExports should return a Set')
+
+console.log('✅ getExports includes non-enumerable built-in module exports')

--- a/test/hook/v22-builtin-non-enumerable-exports.mjs
+++ b/test/hook/v22-builtin-non-enumerable-exports.mjs
@@ -1,0 +1,41 @@
+// node:events exposes kMaxEventTargetListeners and kMaxEventTargetListenersWarned
+// as non-enumerable own properties. With Object.keys() these were silently
+// dropped from the exports set and would not appear in the IITM shim at all.
+// With Object.getOwnPropertyNames() they are included in the shim.
+//
+// Note: even though Node's ESM namespace doesn't directly expose the Symbol
+// values behind these keys, the IITM shim includes them so that they are
+// observable (e.g. via the `in` operator) and can be overridden by hooks.
+
+import { ok } from 'assert'
+import Hook from '../../index.js'
+
+let capturedExports = null
+const hook = new Hook(['events'], (exports, name) => {
+  if (name === 'events') {
+    capturedExports = exports
+  }
+})
+
+await import('node:events')
+
+ok(capturedExports !== null, 'Hook should have fired for node:events')
+
+// Verify non-enumerable own properties of the events module's CJS export object
+// are present as named exports in the IITM hook namespace.
+// These properties are NOT in Object.keys(require('events')) — only in
+// Object.getOwnPropertyNames(require('events')).
+ok(
+  'kMaxEventTargetListeners' in capturedExports,
+  'non-enumerable kMaxEventTargetListeners should be present in IITM hook exports'
+)
+ok(
+  'kMaxEventTargetListenersWarned' in capturedExports,
+  'non-enumerable kMaxEventTargetListenersWarned should be present in IITM hook exports'
+)
+
+// Verify enumerable exports are still present
+ok(typeof capturedExports.default === 'function', 'default (EventEmitter) should be present')
+ok(typeof capturedExports.EventEmitter === 'function', 'EventEmitter named export should be present')
+
+hook.unhook()

--- a/test/hook/v22-builtin-require-esm-class-extends.mjs
+++ b/test/hook/v22-builtin-require-esm-class-extends.mjs
@@ -1,0 +1,56 @@
+// when IITM wraps a builtin (e.g. node:events), CJS modules
+// that call require('node:events') via the require(esm) path (Node 22+) must
+// receive a real constructor, not the IITM proxy object.
+//
+// On Node 24+, when a CJS module is loaded by an IITM shim via loadCJSModule,
+// its require() calls for builtins are routed through the ESM resolver. IITM
+// tracks such CJS modules in cjsInIitmChain (create-hook.mjs) and bypasses
+// wrapping for their require() calls, so require('node:events') returns the
+// native EventEmitter rather than the IITM namespace object. Without this
+// bypass, the namespace object (Symbol.toStringTag === 'Module') is returned,
+// causing:
+//   TypeError: Class extends value [object Module] is not a constructor or null
+
+const [NODE_MAJOR] = process.versions.node.split('.').map(Number)
+if (NODE_MAJOR < 22) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url} ...`)
+  process.exit(0)
+}
+
+import { strictEqual, ok } from 'assert'
+import Hook from '../../index.js'
+
+let hookedEvents = false
+const hook = new Hook(['events'], (exports, name) => {
+  if (name === 'events') {
+    hookedEvents = true
+  }
+})
+
+// Load node:events via ESM so IITM wraps it. On Node 24+, the CJS fixture
+// below is loaded via loadCJSModule inside the IITM shim, so its require()
+// calls are routed through the ESM resolver and intercepted by IITM.
+await import('node:events')
+
+ok(hookedEvents, 'IITM hook should have fired for node:events')
+
+// Import the CJS fixture that does `class Foo extends require('node:events') {}`.
+// If the cjsInIitmChain bypass is missing, this import will throw:
+//   TypeError: Class extends value [object Module] is not a constructor or null
+const mod = await import('../fixtures/cjs-extends-events.js')
+const Foo = mod.default
+
+ok(typeof Foo === 'function', 'Foo should be a constructor function')
+
+// Verify the class actually works — instances should be EventEmitters
+const foo = new Foo()
+ok(typeof foo.on === 'function', 'instance should inherit EventEmitter.on')
+ok(typeof foo.emit === 'function', 'instance should inherit EventEmitter.emit')
+
+// Verify basic EventEmitter behaviour is intact
+let received = null
+foo.on('test', (v) => { received = v })
+foo.emit('test', 42)
+strictEqual(received, 42, 'EventEmitter events should work')
+
+hook.unhook()

--- a/test/hook/v22-builtin-require-esm-class-extends.mjs
+++ b/test/hook/v22-builtin-require-esm-class-extends.mjs
@@ -11,12 +11,6 @@
 // causing:
 //   TypeError: Class extends value [object Module] is not a constructor or null
 
-const [NODE_MAJOR] = process.versions.node.split('.').map(Number)
-if (NODE_MAJOR < 22) {
-  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url} ...`)
-  process.exit(0)
-}
-
 import { strictEqual, ok } from 'assert'
 import Hook from '../../index.js'
 

--- a/test/hook/v22-cjs-require-module-sync-with-source-hook.mjs
+++ b/test/hook/v22-cjs-require-module-sync-with-source-hook.mjs
@@ -1,0 +1,36 @@
+// Regression test for ERR_VM_MODULE_LINK_FAILURE when:
+// 1. A CJS module is loaded through an ESM import chain
+// 2. Another loader hook provides source for CJS modules (like @apm-js-collab/tracing-hooks)
+// 3. The CJS module require()s a package with "module-sync" exports condition
+//
+// On Node 22+, providing source for CJS modules via hooks changes how
+// require() works inside those modules. Specifically, require() of packages
+// that resolve to ESM files (via module-sync condition) fails because
+// ModuleJob.runSync cannot link the ESM file's dependencies.
+//
+// IITM fixes this by stripping hook-provided source for CJS modules in the
+// cjsInIitmChain, forcing Node to use its native CJS loader.
+
+import { strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+const hook = new Hook((exports, name) => {
+  // Hook all modules
+})
+
+// This import triggers the chain:
+// ESM (this file) → CJS (cjs-requires-module-sync.js) → module-sync (require.mjs) → CJS (index.js)
+// The source-providing-hook (registered via --import) provides source for CJS
+// modules. Without the fix, this throws ERR_VM_MODULE_LINK_FAILURE.
+const mod = await import('../fixtures/cjs-requires-module-sync.js')
+
+// The result should be accessible (not crash with ERR_VM_MODULE_LINK_FAILURE).
+// The actual value depends on whether module-sync condition is used.
+const result = mod.default.result
+strictEqual(typeof result, 'string', 'require() of module-sync package should succeed')
+strictEqual(
+  result === 'from-cjs-via-module-sync' || result === 'from-cjs', true,
+  `result should be from module-sync or CJS path, got: ${result}`
+)
+
+hook.unhook()

--- a/test/hook/v22-cjs-transitive-require-chain.mjs
+++ b/test/hook/v22-cjs-transitive-require-chain.mjs
@@ -1,0 +1,32 @@
+// Regression test for ERR_VM_MODULE_LINK_FAILURE when a CJS module loaded
+// through an ESM import chain has transitive require() calls.
+//
+// Scenario (mirrors graphql-koa-dataloader app):
+//   ESM app → imports CJS-A (e.g. koa)
+//           → CJS-A require()s CJS-B (e.g. is-generator-function)
+//           → CJS-B require()s CJS-C (e.g. has-tostringtag)
+//
+// Without the fix, IITM wraps CJS-C because CJS-B's URL is not in
+// cjsInIitmChain. The wrapper introduces `import { register } from '...'`
+// which cannot be linked synchronously via ModuleJob.runSync, causing:
+//   Error: request for 'file:///.../register.js' is from a module not been linked
+
+import { strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+const hooked = []
+const hook = new Hook((exports, name) => {
+  hooked.push(name)
+})
+
+// Import the top-level CJS module. This triggers the full transitive chain:
+// cjs-transitive-a → requires cjs-transitive-b → requires cjs-transitive-c
+// If cjsInIitmChain propagation is broken, this will throw
+// ERR_VM_MODULE_LINK_FAILURE on cjs-transitive-c.
+const mod = await import('../fixtures/cjs-transitive-a.js')
+
+strictEqual(mod.default.own, 'top', 'top-level CJS export should be accessible')
+strictEqual(mod.default.fromB, 'middle', 'middle CJS export should propagate')
+strictEqual(mod.default.fromC, 'deep', 'deep CJS export should propagate')
+
+hook.unhook()

--- a/test/hook/v23-builtin-module-exports-shim.mjs
+++ b/test/hook/v23-builtin-module-exports-shim.mjs
@@ -1,0 +1,63 @@
+// when IITM wraps a builtin (e.g. node:events):
+//  * IITM hook proxy (capturedExports) exposes 'module.exports' as the real
+//    CJS value (e.g. EventEmitter), falling back to $default because the native
+//    ESM namespace doesn't expose it. This lets instrumentors intercept/replace
+//    the CJS-equivalent export of a builtin.
+//
+//  * IITM shim's ESM namespace does NOT re-export 'module.exports' as a
+//    named export. Native builtins don't have it, so including it would cause
+//    check-exports failures (Object.keys mismatches) for any package that wraps
+//    a builtin and compares its exports against the unwrapped original.
+
+import { ok, strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+let capturedExports = null
+const hook = new Hook(['events'], (exports, name) => {
+  if (name === 'events') {
+    capturedExports = exports
+  }
+})
+
+const eventsNs = await import('node:events')
+
+ok(capturedExports !== null, 'Hook should have fired for node:events')
+
+// ESM namespace must NOT expose 'module.exports' as a named
+// export — native builtins don't have it, so adding it would cause check-exports
+// mismatches for packages that compare wrapped vs unwrapped builtin exports.
+strictEqual(
+  eventsNs['module.exports'],
+  undefined,
+  "'module.exports' should not be a named export on the IITM shim ESM namespace"
+)
+ok(
+  typeof eventsNs.default === 'function',
+  'default export (EventEmitter) should still be present on the ESM namespace'
+)
+
+// IITM hook proxy must expose 'module.exports' as the real CJS
+// value via the $default fallback, so instrumentors can intercept it.
+ok(
+  'module.exports' in capturedExports,
+  "'module.exports' should be present in IITM hook exports for a builtin"
+)
+
+const ModuleExportsValue = capturedExports['module.exports']
+ok(
+  typeof ModuleExportsValue === 'function',
+  "'module.exports' export should be the EventEmitter constructor, not undefined"
+)
+
+// Verify it's actually EventEmitter (default export and module.exports are the same thing)
+strictEqual(
+  ModuleExportsValue,
+  capturedExports.default,
+  "'module.exports' should be the same as the default export (EventEmitter)"
+)
+
+// Verify the exported value works as a constructor
+const instance = new ModuleExportsValue()
+ok(typeof instance.on === 'function', 'Constructed instance should have EventEmitter methods')
+
+hook.unhook()


### PR DESCRIPTION
At New Relic we've been in the process of migrating our instrumentation to rely on tracing channel via [orchestrion-js](https://github.com/nodejs/orchestrion-js) and the [tracing hooks](https://github.com/apm-js-collab/tracing-hooks). We noticed some incompatibilities when registering both IITM and `@apm-js-collab/tracing-hooks`.  I was able to distill it down to edge cases of built in packages.  

 When IITM wraps a Node built-in (e.g. node:events, diagnostics_channel),
  CJS modules that call require() on it via Node 22+'s require(esm) path
  would receive either the raw IITM proxy or undefined, causing:
    - TypeError: Class extends value [object Module] is not a constructor
    - TypeError: Cannot destructure property 'tracingChannel' of undefined

  Four fixes:
  - Explicitly add 'module.exports' to the builtin exports set on Node >= 23,
    where it is a synthetic named ESM export for CJS modules
  - Keep track of cjs modules imported and do not wrap so when requiring module it returns the appropriate export
  - Add a $default fallback in the generated shim for the module.exports
    binding, so that when namespace['module.exports'] is undefined (Node
    doesn't expose it for all builtins), the actual CJS module.exports value
    is used instead
  - Use Object.getOwnPropertyNames (instead of Object.keys) when building
    the exports set for builtins, so non-enumerable properties are included


This was all observed when creating an esm app and importing koa. Since our agent rewrites koa files with orchestrion-js, it was producing the crashes above.

EDIT:

I still had an issue on node 22 and could not figure out how to solve. I used claude and it came up with a fix and also some good tests that mimic the behavior between iitm, tracing hooks and a package like koa. This was its summary of the fix:

```
 ---
  Root Cause

  Two issues compound to cause ERR_VM_MODULE_LINK_FAILURE:

  1. Node.js bug (Node 22+): When a CJS module is loaded through the ESM translator and a loader hook provides its source
  (instead of leaving it null for Node to read natively), require() calls inside that CJS module fail for packages using the
   "module-sync" exports condition (like generator-function). The module-sync condition resolves to an ESM file
  (require.mjs), which imports CJS files — and ModuleJob.runSync can't link those dependencies when hook-provided source
  changes the CJS loading path.

  2. Missing propagation in cjsInIitmChain: IITM tracked top-level CJS modules it wrapped, but didn't propagate the
  "in-chain" status to their transitive require() targets. So koa/lib/application.js was in the set, but its children
  (is-generator-function, call-bound, etc.) were not.

  Fix (in create-hook.mjs)

  1. Resolve hook — Propagate cjsInIitmChain membership to child modules so the entire synchronous CJS require tree is
  tracked:
  if (cjsInIitmChain.has(parentURL)) {
    cjsInIitmChain.add(result.url) // NEW
    return result
  }
  2. Load hook — Strip hook-provided source for CJS modules in the chain, forcing Node to use its native CJS loader which
  handles module-sync correctly:
  if (cjsInIitmChain.has(url)) {
    const result = await parentLoad(url, context)
    if (result.format === 'commonjs' && result.source != null) {
      return { format: result.format, source: undefined }
    }
    return result
  }

  Test Files Added

  - test/hook/v22-cjs-transitive-require-chain.mjs — Tests cjsInIitmChain propagation
  - test/hook/v22-cjs-require-module-sync-with-source-hook.mjs — Tests the full scenario with a source-providing hook (run
  with --import test/fixtures/register-iitm-with-source-hook.mjs)
  - Supporting fixtures in test/fixtures/
 ```