### PR TITLE
feat: add shouldInclude predicate for consumer-owned module matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,36 @@ node --import=./instrument.mjs ./my-app.mjs
 `register()` accepts the same `include` / `exclude` options as the asynchronous
 loader and throws on a Node.js version without `module.registerHooks()`.
 
+### Custom matching with `shouldInclude`
+
+Instead of `include` / `exclude` lists, you can pass a `shouldInclude(url, specifier)`
+predicate to decide which modules are intercepted. It is called for every resolved
+module with the resolved URL and the import specifier; return a truthy value to
+intercept the module. When a predicate is provided it takes over the decision and
+the `include` / `exclude` options are ignored.
+
+This is useful when matching doesn't map cleanly onto bare specifiers, file URLs and
+regular expressions — for example a matcher built from your own configuration, or a
+decision that depends on more than the specifier.
+
+```js
+import { register } from 'import-in-the-middle/register-hooks.mjs'
+
+register({
+  shouldInclude (url, specifier) {
+    return specifier === 'package-i-want-to-include' ||
+      url.includes('/node_modules/some-scope/')
+  }
+})
+```
+
+The predicate receives only the URL and the specifier, never a resolved file path.
+Because `module.register()` transfers its `data` to the loader thread by structured
+clone — which cannot carry a function — `shouldInclude` is supported for synchronous
+registration (`register-hooks.mjs`, shown above) and for predicates constructed on
+the loader thread; it is not accepted through the `data` option of the asynchronous
+`module.register('import-in-the-middle/hook.mjs', ...)`.
+
 ## Limitations
 
 * You cannot add new exports to a module. You can only modify existing ones.

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -352,7 +352,8 @@ function addIitm (url) {
 export function createHook (meta) {
   let cachedResolve
   const iitmURL = new URL('lib/register.js', meta.url).toString()
-  let includeModules, excludeModules, shouldInclude
+  let includeModules, excludeModules
+  let shouldInclude = defaultShouldInclude
 
   // Track CJS module URLs that IITM has wrapped. On Node 24+, CJS modules loaded
   // via loadCJSModule (in an ESM import chain) have their require() calls for
@@ -361,6 +362,43 @@ export function createHook (meta) {
   // of the native CJS module value (e.g. EventEmitter constructor), breaking
   // patterns like `class App extends require('events') {}`.
   const cjsInIitmChain = new Set()
+
+  // Default matcher, used unless the consumer supplies its own `shouldInclude`
+  // (see applyOptions). It applies the include/exclude lists, so finishResolve
+  // always has a predicate to call and never has to special-case its absence.
+  //
+  // We check the specifier to match libraries loaded with bare specifiers from
+  // node_modules, and the full file URL for non-bare specifier imports (relative
+  // paths would be error prone). An absolute path entry added via Hook over the
+  // message port matches the resolved file path, so it is resolved here.
+  function defaultShouldInclude (url, specifier) {
+    let resultPath
+    if (url.startsWith('file:')) {
+      const stackTraceLimit = Error.stackTraceLimit
+      Error.stackTraceLimit = 0
+      try {
+        resultPath = fileURLToPath(url)
+      } catch {}
+      Error.stackTraceLimit = stackTraceLimit
+    }
+    function match (each) {
+      if (each instanceof RegExp) {
+        return each.test(url)
+      }
+
+      return each === specifier || each === url || (resultPath && each === resultPath)
+    }
+
+    if (includeModules && !includeModules.some(match)) {
+      return false
+    }
+
+    if (excludeModules && excludeModules.some(match)) {
+      return false
+    }
+
+    return true
+  }
 
   // Applies the include/exclude/message-port configuration. Shared by the
   // asynchronous `initialize` (off-thread `module.register`, which receives
@@ -373,9 +411,10 @@ export function createHook (meta) {
 
     // A consumer can supply its own matcher as `shouldInclude(url, specifier)`,
     // taking ownership of the include/exclude decision instead of expressing it
-    // as bare-specifier / file-URL / regex lists. When given, it replaces the
-    // include/exclude options and is called with the resolved URL and specifier.
-    shouldInclude = typeof data.shouldInclude === 'function' ? data.shouldInclude : undefined
+    // as bare-specifier / file-URL / regex lists. It replaces the default list
+    // matcher and is called with the resolved URL and specifier; otherwise the
+    // default applies the include/exclude options.
+    shouldInclude = typeof data.shouldInclude === 'function' ? data.shouldInclude : defaultShouldInclude
 
     if (data.addHookMessagePort) {
       data.addHookMessagePort.on('message', (modules) => {
@@ -442,42 +481,10 @@ export function createHook (meta) {
       return result
     }
 
-    if (shouldInclude !== undefined) {
-      // Consumer-owned matcher: it decides from the URL and specifier alone, so
-      // the resolved file path is neither computed nor passed here.
-      if (!shouldInclude(result.url, specifier)) {
-        return result
-      }
-    } else {
-      // For included/excluded modules, we check the specifier to match libraries
-      // that are loaded with bare specifiers from node_modules.
-      //
-      // For non-bare specifier imports, we match to the full file URL because
-      // using relative paths would be very error prone!
-      let resultPath
-      if (result.url.startsWith('file:')) {
-        const stackTraceLimit = Error.stackTraceLimit
-        Error.stackTraceLimit = 0
-        try {
-          resultPath = fileURLToPath(result.url)
-        } catch {}
-        Error.stackTraceLimit = stackTraceLimit
-      }
-      function match (each) {
-        if (each instanceof RegExp) {
-          return each.test(result.url)
-        }
-
-        return each === specifier || each === result.url || (resultPath && each === resultPath)
-      }
-
-      if (includeModules && !includeModules.some(match)) {
-        return result
-      }
-
-      if (excludeModules && excludeModules.some(match)) {
-        return result
-      }
+    // `shouldInclude` is always set (the include/exclude list matcher by default,
+    // a consumer-provided predicate otherwise), so no nullish check is needed.
+    if (!shouldInclude(result.url, specifier)) {
+      return result
     }
 
     if (isIitm(parentURL, meta) || (parentURL && hasIitm(parentURL))) {

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -352,7 +352,7 @@ function addIitm (url) {
 export function createHook (meta) {
   let cachedResolve
   const iitmURL = new URL('lib/register.js', meta.url).toString()
-  let includeModules, excludeModules
+  let includeModules, excludeModules, shouldInclude
 
   // Track CJS module URLs that IITM has wrapped. On Node 24+, CJS modules loaded
   // via loadCJSModule (in an ESM import chain) have their require() calls for
@@ -370,6 +370,12 @@ export function createHook (meta) {
   function applyOptions (data) {
     includeModules = ensureArrayWithBareSpecifiersFileUrlsAndRegex(data.include, 'include')
     excludeModules = ensureArrayWithBareSpecifiersFileUrlsAndRegex(data.exclude, 'exclude')
+
+    // A consumer can supply its own matcher as `shouldInclude(url, specifier)`,
+    // taking ownership of the include/exclude decision instead of expressing it
+    // as bare-specifier / file-URL / regex lists. When given, it replaces the
+    // include/exclude options and is called with the resolved URL and specifier.
+    shouldInclude = typeof data.shouldInclude === 'function' ? data.shouldInclude : undefined
 
     if (data.addHookMessagePort) {
       data.addHookMessagePort.on('message', (modules) => {
@@ -417,6 +423,12 @@ export function createHook (meta) {
       return result
     }
 
+    // Never wrap a module whose format we don't handle (e.g. json, wasm); this
+    // holds regardless of how inclusion is decided below.
+    if (result.format && !HANDLED_FORMATS.has(result.format)) {
+      return result
+    }
+
     // The synchronous hooks (`module.registerHooks`) fire for `require()` as well
     // as `import`, but iitm only owns the ESM graph: CommonJS modules are
     // instrumented separately through require-in-the-middle, and `require()` must
@@ -430,38 +442,42 @@ export function createHook (meta) {
       return result
     }
 
-    // For included/excluded modules, we check the specifier to match libraries
-    // that are loaded with bare specifiers from node_modules.
-    //
-    // For non-bare specifier imports, we match to the full file URL because
-    // using relative paths would be very error prone!
-    let resultPath
-    if (result.url.startsWith('file:')) {
-      const stackTraceLimit = Error.stackTraceLimit
-      Error.stackTraceLimit = 0
-      try {
-        resultPath = fileURLToPath(result.url)
-      } catch {}
-      Error.stackTraceLimit = stackTraceLimit
-    }
-    function match (each) {
-      if (each instanceof RegExp) {
-        return each.test(result.url)
+    if (shouldInclude !== undefined) {
+      // Consumer-owned matcher: it decides from the URL and specifier alone, so
+      // the resolved file path is neither computed nor passed here.
+      if (!shouldInclude(result.url, specifier)) {
+        return result
+      }
+    } else {
+      // For included/excluded modules, we check the specifier to match libraries
+      // that are loaded with bare specifiers from node_modules.
+      //
+      // For non-bare specifier imports, we match to the full file URL because
+      // using relative paths would be very error prone!
+      let resultPath
+      if (result.url.startsWith('file:')) {
+        const stackTraceLimit = Error.stackTraceLimit
+        Error.stackTraceLimit = 0
+        try {
+          resultPath = fileURLToPath(result.url)
+        } catch {}
+        Error.stackTraceLimit = stackTraceLimit
+      }
+      function match (each) {
+        if (each instanceof RegExp) {
+          return each.test(result.url)
+        }
+
+        return each === specifier || each === result.url || (resultPath && each === resultPath)
       }
 
-      return each === specifier || each === result.url || (resultPath && each === resultPath)
-    }
+      if (includeModules && !includeModules.some(match)) {
+        return result
+      }
 
-    if (result.format && !HANDLED_FORMATS.has(result.format)) {
-      return result
-    }
-
-    if (includeModules && !includeModules.some(match)) {
-      return result
-    }
-
-    if (excludeModules && excludeModules.some(match)) {
-      return result
+      if (excludeModules && excludeModules.some(match)) {
+        return result
+      }
     }
 
     if (isIitm(parentURL, meta) || (parentURL && hasIitm(parentURL))) {

--- a/test/register/v22.15-sync-register-hooks-should-include.mjs
+++ b/test/register/v22.15-sync-register-hooks-should-include.mjs
@@ -1,0 +1,43 @@
+// A consumer can pass `shouldInclude(url, specifier)` to take over the
+// include/exclude decision. iitm then skips the include/exclude lists and the
+// per-resolve file-path resolution the list matcher would otherwise need, so the
+// predicate is called with exactly two arguments (no resolved file path).
+
+import * as nodeModule from 'node:module'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+import Hook from '../../index.js'
+import { ok, strictEqual } from 'node:assert'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+let thirdArg = 'unset'
+register({
+  shouldInclude (url, specifier, path) {
+    thirdArg = path
+    return /something\.mjs/.test(url)
+  }
+})
+
+let somethingHooked = false
+let bHooked = false
+
+// eslint-disable-next-line no-new
+new Hook((exports, name) => {
+  if (typeof name === 'string' && /something\.mjs/.test(name)) somethingHooked = true
+  if (typeof name === 'string' && /\bb\.mjs/.test(name)) bHooked = true
+})
+
+await import('../fixtures/something.mjs')
+await import('../fixtures/b.mjs')
+
+ok(somethingHooked, 'module the predicate accepts should be wrapped and hooked')
+strictEqual(bHooked, false, 'module the predicate rejects should not be wrapped')
+strictEqual(thirdArg, undefined, 'iitm must not compute or pass the file path to shouldInclude')
+
+// sanity: the predicate path is only taken when registerHooks is available.
+ok(typeof nodeModule.registerHooks === 'function')
+
+console.log('✅ shouldInclude gates wrapping and is called with (url, specifier) only')


### PR DESCRIPTION
## Summary

`include`/`exclude` only accept bare specifiers, file URLs, and regular expressions. Consumers that need different matching — a matcher built from their own config, a prefix/glob scheme, or a decision based on more than the specifier — have to encode everything into those shapes or run a parallel filter outside iitm.

This adds an optional `shouldInclude(url, specifier)` predicate. When provided, it replaces the include/exclude lists: iitm calls it for each resolved module and the consumer owns the decision, keeping its matching in one place. The predicate receives the resolved URL and the specifier; iitm does not resolve a file path for it (the list matcher still does, for absolute-path entries added via `Hook` over the message port).

`module.register` structured-clones its `data`, so a function can't be passed through it — the predicate is for synchronous registration (`module.registerHooks` / `register-hooks.mjs`) or a predicate built on the loader thread. `include`/`exclude` remain fully supported when no predicate is given.

As a drive-by, the `result.format` guard is hoisted to the top of `finishResolve` so it applies to both the predicate and list paths (a predicate can legitimately match a non-JS format such as `node_modules/<pkg>/package.json`).

## Test plan

- [ ] New `test/register/v22.15-sync-register-hooks-should-include.mjs`: the predicate gates wrapping and is called with `(url, specifier)` only.
- [ ] Existing include/exclude and `v18.19-include-message-port-absolute-path` tests pass unchanged (list path untouched).