### PR TITLE
refactor: extract supportsSyncHooks into an import-free module

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,32 @@ node --import=./instrument.mjs ./my-app.mjs
 
 ## Synchronous loader hooks
 
-On Node.js versions that provide
+On Node.js versions that support
 [`module.registerHooks()`](https://nodejs.org/api/module.html#moduleregisterhooksoptions)
-(>= 22.15.0 / >= 24.0.0) the loader can run *synchronously*, on the application
-thread, instead of on the separate thread that `module.register()` uses. Running
-in-thread removes the message channel: `Hook()` registrations are visible to the
-loader directly, so the `createAddHookMessageChannel` /
-`waitForAllMessagesAcknowledged` step shown above is unnecessary.
+the loader can run *synchronously*, on the application thread, instead of on the
+separate thread that `module.register()` uses. Running in-thread removes the
+message channel: `Hook()` registrations are visible to the loader directly, so
+the `createAddHookMessageChannel` / `waitForAllMessagesAcknowledged` step shown
+above is unnecessary.
+
+`module.registerHooks()` was added in 22.15.0 / 24.0.0, but its synchronous load
+hook rejected the nullish CommonJS `source` the loader returns for `require()`s
+pulled into the ESM graph until [nodejs/node#59929][]. The fix shipped in
+**22.22.3, 24.11.1, 25.1.0 and 26.0.0**; earlier versions ship
+`module.registerHooks()` but cannot run the synchronous loader. Use
+`supportsSyncHooks()` to branch on this rather than a hand-written version check:
+
+```js
+import { register, supportsSyncHooks } from 'import-in-the-middle/register-hooks.mjs'
+
+if (supportsSyncHooks()) {
+  register({ include: ['package-i-want-to-include'] })
+} else {
+  // Fall back to the asynchronous loader, e.g. module.register('import-in-the-middle/hook.mjs').
+}
+```
+
+[nodejs/node#59929]: https://github.com/nodejs/node/pull/59929
 
 `instrument.mjs`
 
@@ -143,7 +162,7 @@ node --import=./instrument.mjs ./my-app.mjs
 ```
 
 `register()` accepts the same `include` / `exclude` options as the asynchronous
-loader and throws on a Node.js version without `module.registerHooks()`.
+loader and throws on a Node.js version where `supportsSyncHooks()` is `false`.
 
 ### Custom matching with `shouldInclude`
 

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -10,6 +10,12 @@ import {
   hasModuleExportsCJSDefault
 } from './lib/get-exports.mjs'
 import { RESOLVE, driveSync, driveAsync } from './lib/io.mjs'
+import { supportsSyncHooks } from './supports-sync-hooks.mjs'
+
+// Re-exported for backwards compatibility: `supportsSyncHooks` now lives in its
+// own import-free module so a CommonJS preloader can check it without loading
+// this file's acorn / cjs-module-lexer dependency graph.
+export { supportsSyncHooks }
 
 const specifiers = new Map()
 const isWin = process.platform === 'win32'
@@ -19,33 +25,6 @@ const isWin = process.platform === 'win32'
 const EXTENSION_RE = /\.(js|mjs|cjs|ts|mts|cts)$/
 const HANDLED_FORMATS = new Set(['builtin', 'module', 'commonjs'])
 const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
-
-// process.versions.node is always "major.minor.patch" (nightlies add a suffix
-// the regex ignores).
-const [, NODE_MAJOR, NODE_MINOR, NODE_PATCH] =
-  process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/).map(Number)
-
-/**
- * Whether the running Node.js can correctly run the synchronous loader via
- * `module.registerHooks`.
- *
- * `module.registerHooks` exists since v22.15, but its synchronous load hook
- * rejected the nullish CommonJS `source` the loader returns for `require()`s
- * pulled into the ESM graph (throwing `ERR_INVALID_RETURN_PROPERTY_VALUE`) until
- * https://github.com/nodejs/node/pull/59929, released in 22.22.3, 24.11.1,
- * 25.1.0 and 26.0.0. Earlier 24.x (<= 24.11.0) and 25.0.0 ship `registerHooks`
- * but predate the fix, so the synchronous loader must fall back to the
- * asynchronous one there.
- *
- * @returns {boolean}
- */
-export function supportsSyncHooks () {
-  if (NODE_MAJOR >= 26) return true
-  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
-  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
-  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
-  return false
-}
 
 function hasIitm (url) {
   // Fast path: avoid URL parsing on the hot path when there's clearly no iitm.

--- a/register-hooks.d.ts
+++ b/register-hooks.d.ts
@@ -17,7 +17,8 @@ export type RegisterHooksOptions = {
  * synchronous hooks run on the application thread, so `Hook()` registrations are
  * visible to the loader directly and no acknowledgement step is required.
  *
- * Requires a Node.js version with `module.registerHooks()` (>= 22.15.0 / >= 24).
+ * Requires a Node.js version where {@link supportsSyncHooks} is `true`
+ * (>= 22.22.3, >= 24.11.1, >= 25.1.0, or >= 26.0.0).
  *
  * ```ts
  * import { register } from 'import-in-the-middle/register-hooks.mjs'
@@ -30,6 +31,14 @@ export type RegisterHooksOptions = {
  * })
  * ```
  *
- * @throws If `module.registerHooks()` is unavailable in the running Node.js.
+ * @throws If {@link supportsSyncHooks} is `false` in the running Node.js.
  */
 export declare function register(options?: RegisterHooksOptions): void
+
+/**
+ * Whether the running Node.js can correctly run the synchronous loader via
+ * `module.registerHooks()`. `false` on versions that ship `module.registerHooks()`
+ * but predate the nullish-CommonJS-`source` fix (nodejs/node#59929); branch on it
+ * to fall back to the asynchronous `module.register()` loader.
+ */
+export declare function supportsSyncHooks(): boolean

--- a/register-hooks.mjs
+++ b/register-hooks.mjs
@@ -1,5 +1,6 @@
 import * as module from 'module'
-import { createHook, supportsSyncHooks } from './create-hook.mjs'
+import { createHook } from './create-hook.mjs'
+import { supportsSyncHooks } from './supports-sync-hooks.mjs'
 
 export { supportsSyncHooks }
 

--- a/supports-sync-hooks.mjs
+++ b/supports-sync-hooks.mjs
@@ -7,10 +7,20 @@
 // whether to require the ESM loader at all) need to call it without pulling in
 // `create-hook.mjs` and its acorn / cjs-module-lexer dependency graph.
 
-// process.versions.node is always "major.minor.patch" (nightlies add a suffix
-// the regex ignores).
-const [, NODE_MAJOR, NODE_MINOR, NODE_PATCH] =
-  process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/).map(Number)
+// `process.versions.node` is always "major.minor.patch" (nightlies append a
+// "-suffix" that parseInt stops at). Only release lines 22/24/25 need the minor
+// and patch, so parse the major eagerly and read those lazily.
+const version = process.versions.node
+const NODE_MAJOR = parseInt(version, 10)
+let NODE_MINOR
+let NODE_PATCH
+
+function readMinorAndPatch () {
+  const firstDot = version.indexOf('.')
+  const secondDot = version.indexOf('.', firstDot + 1)
+  NODE_MINOR = parseInt(version.slice(firstDot + 1, secondDot), 10)
+  NODE_PATCH = parseInt(version.slice(secondDot + 1), 10)
+}
 
 /**
  * Whether the running Node.js can correctly run the synchronous loader via
@@ -28,8 +38,10 @@ const [, NODE_MAJOR, NODE_MINOR, NODE_PATCH] =
  */
 export function supportsSyncHooks () {
   if (NODE_MAJOR >= 26) return true
+  if (NODE_MAJOR < 22 || NODE_MAJOR === 23) return false
+
+  readMinorAndPatch()
   if (NODE_MAJOR === 25) return NODE_MINOR >= 1
   if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
-  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
-  return false
+  return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
 }

--- a/supports-sync-hooks.mjs
+++ b/supports-sync-hooks.mjs
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+// This module intentionally has no imports. `supportsSyncHooks` is a pure
+// Node.js version check, and consumers (e.g. a CommonJS preloader deciding
+// whether to require the ESM loader at all) need to call it without pulling in
+// `create-hook.mjs` and its acorn / cjs-module-lexer dependency graph.
+
+// process.versions.node is always "major.minor.patch" (nightlies add a suffix
+// the regex ignores).
+const [, NODE_MAJOR, NODE_MINOR, NODE_PATCH] =
+  process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/).map(Number)
+
+/**
+ * Whether the running Node.js can correctly run the synchronous loader via
+ * `module.registerHooks`.
+ *
+ * `module.registerHooks` exists since v22.15, but its synchronous load hook
+ * rejected the nullish CommonJS `source` the loader returns for `require()`s
+ * pulled into the ESM graph (throwing `ERR_INVALID_RETURN_PROPERTY_VALUE`) until
+ * https://github.com/nodejs/node/pull/59929, released in 22.22.3, 24.11.1,
+ * 25.1.0 and 26.0.0. Earlier 24.x (<= 24.11.0) and 25.0.0 ship `registerHooks`
+ * but predate the fix, so the synchronous loader must fall back to the
+ * asynchronous one there.
+ *
+ * @returns {boolean}
+ */
+export function supportsSyncHooks () {
+  if (NODE_MAJOR >= 26) return true
+  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
+  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
+  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
+  return false
+}

--- a/test/loaders/specifiers-map-cleanup-loader.mjs
+++ b/test/loaders/specifiers-map-cleanup-loader.mjs
@@ -9,8 +9,9 @@ const createHookUrl = new URL('../../create-hook.mjs', import.meta.url)
 let src = readFileSync(createHookUrl, 'utf8')
 // We evaluate a modified copy of create-hook.mjs from a data: URL (to append
 // `export { specifiers }`). data: URLs have no hierarchical base, so rewrite
-// every relative `./lib/...` import to an absolute file URL first.
-src = src.replace(/from '(\.\/lib\/[^']+)'/g, (_match, relative) => {
+// every relative `./...` import (./lib/*, ./supports-sync-hooks.mjs, ...) to an
+// absolute file URL first.
+src = src.replace(/from '(\.\/[^']+)'/g, (_match, relative) => {
   const absolute = new URL('../../' + relative.slice(2), import.meta.url).href
   return `from ${JSON.stringify(absolute)}`
 })


### PR DESCRIPTION
## Summary

`supportsSyncHooks` is a pure Node.js version check, but it currently lives in `create-hook.mjs` next to the loader's `acorn` / `cjs-module-lexer` dependency graph. A CommonJS preloader that wants to decide *whether to load the synchronous ESM loader at all* has to import `create-hook.mjs` (or `register-hooks.mjs`, which pulls it in) just to call the check — loading the transformer machinery on the main thread even on runtimes where the synchronous loader cannot run.

This moves `supportsSyncHooks` into a new, import-free `supports-sync-hooks.mjs` and re-exports it from both `create-hook.mjs` and `register-hooks.mjs`, so:

- every existing import path keeps working (`import { supportsSyncHooks } from 'import-in-the-middle/create-hook.mjs'` and `.../register-hooks.mjs`), and
- consumers can import the predicate on its own without paying for the loader's dependencies.

## Motivation

In dd-trace-js the synchronous loader is registered from a CommonJS preloader (`register.js`). It needs `supportsSyncHooks` to decide whether to `require()` the ESM loader, but importing it today would build the code transformer on the application's main thread on unsupported Node versions — the exact startup cost the check exists to avoid. We currently duplicate the version thresholds to work around this; a standalone export lets us drop the copy and keep a single source of truth here.

## Test plan

- Existing `test/register/*` suite passes unchanged (16/16 locally on Node 22.22), including the `shouldInclude` and sync-register-hooks tests.
- Verified all three import paths (`supports-sync-hooks.mjs`, `create-hook.mjs`, `register-hooks.mjs`) export the same function.