### PR TITLE
fix: instrument type-stripped TypeScript modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,34 @@ registration (`register-hooks.mjs`, shown above) and for predicates constructed 
 the loader thread; it is not accepted through the `data` option of the asynchronous
 `module.register('import-in-the-middle/hook.mjs', ...)`.
 
+## TypeScript modules
+
+On Node.js versions that strip TypeScript types natively (those exposing
+[`module.stripTypeScriptTypes()`](https://nodejs.org/api/module.html#modulestriptypescripttypescode-options),
+>= 22.13.0 / >= 23.9.0 / >= 24.0.0), `import-in-the-middle` intercepts `.ts`,
+`.mts` and `.cts` modules just like their JavaScript counterparts. The types are
+stripped before the module's exports are read, so type-only exports
+(`export type`, `export interface`) are not present on the intercepted
+namespace; value exports are.
+
+```ts
+// math.mts
+export type Op = '+' | '-'
+export function add (a: number, b: number): number {
+  return a + b
+}
+```
+
+```js
+Hook(['./math.mts'], (exported) => {
+  // `exported.add` is interceptable; the `Op` type is not part of the namespace
+})
+```
+
+On Node.js versions where type stripping is not enabled by default, run with
+`--experimental-strip-types`. Older versions that predate
+`module.stripTypeScriptTypes()` leave TypeScript modules untouched.
+
 ## Limitations
 
 * You cannot add new exports to a module. You can only modify existing ones.

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -17,7 +17,11 @@ const isWin = process.platform === 'win32'
 // FIXME: Typescript extensions are added temporarily until we find a better
 // way of supporting arbitrary extensions
 const EXTENSION_RE = /\.(js|mjs|cjs|ts|mts|cts)$/
-const HANDLED_FORMATS = new Set(['builtin', 'module', 'commonjs'])
+// The `-typescript` formats are listed unconditionally; getExports strips the
+// types when the runtime supports it and otherwise falls back to onWrapFailure.
+const HANDLED_FORMATS = new Set([
+  'builtin', 'module', 'commonjs', 'module-typescript', 'commonjs-typescript'
+])
 const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
 
 // process.versions.node is always "major.minor.patch" (nightlies add a suffix

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -11,6 +11,11 @@ import { LOAD } from './io.mjs'
 const nodeMajor = Number(process.versions.node.split('.')[0])
 export const hasModuleExportsCJSDefault = nodeMajor >= 23
 
+// Resolve `stripTypeScriptTypes` (Node >= 22.13) via `getBuiltinModule` rather
+// than a static named import (throws on older runtimes) or `require` (re-enters
+// iitm's own loader hooks). `undefined` on runtimes that lack it.
+const stripTypeScriptTypes = process.getBuiltinModule?.('module')?.stripTypeScriptTypes
+
 let parserInitialized = false
 
 // The CJS export scanner is backed by WebAssembly. `initSync` compiles it
@@ -362,11 +367,23 @@ export function * getExports (url, context) {
   }
 
   try {
-    if (format === 'module') {
+    // Node hands the load hook the original TypeScript source, so strip the
+    // types before the JS parsers run, then treat the module as the JS it
+    // compiles to. Early type-stripping releases tag the format but lack the
+    // API; the un-stripped parse then fails cleanly into onWrapFailure.
+    let moduleFormat = format
+    if (format === 'module-typescript' || format === 'commonjs-typescript') {
+      if (stripTypeScriptTypes !== undefined) {
+        source = stripTypeScriptTypes(source, { mode: 'strip' })
+      }
+      moduleFormat = format === 'module-typescript' ? 'module' : 'commonjs'
+    }
+
+    if (moduleFormat === 'module') {
       return getEsmExports(source)
     }
 
-    if (format === 'commonjs') {
+    if (moduleFormat === 'commonjs') {
       return yield * getCjsExports(url, context, source)
     }
 

--- a/test/fixtures/typescript-cjs-hook.cts
+++ b/test/fixtures/typescript-cjs-hook.cts
@@ -1,0 +1,10 @@
+interface Shape { kind: string }
+type Label = string
+
+const epsilon: number = 5
+
+function zeta (s: Shape): Label {
+  return s.kind
+}
+
+module.exports = { epsilon, zeta }

--- a/test/fixtures/typescript-hook.mts
+++ b/test/fixtures/typescript-hook.mts
@@ -1,0 +1,13 @@
+export type OnlyAType = { a: number }
+export interface AlsoAType { b: string }
+export type { Debugger } from 'node:inspector'
+
+export const alpha: number = 1, beta: string = 'two'
+
+export function gamma (n: number): number {
+  return n + alpha
+}
+
+export class Delta {
+  value: number = 3
+}

--- a/test/hook/v24-typescript-hook.mjs
+++ b/test/hook/v24-typescript-hook.mjs
@@ -1,0 +1,44 @@
+import { ok, strictEqual, deepStrictEqual } from 'assert'
+import Hook from '../../index.js'
+
+// Regression for https://github.com/nodejs/import-in-the-middle/issues/186.
+// Under Node's type stripping the loader reports a module as 'module-typescript'
+// / 'commonjs-typescript'; iitm did not recognise those formats, so `.ts`/`.mts`
+// /`.cts` modules were silently left uninstrumented (they still loaded, but no
+// hook ever fired).
+
+let esmExports
+let cjsExports
+
+const hook = new Hook((exports, name) => {
+  if (name.endsWith('typescript-hook.mts')) {
+    esmExports = Object.keys(exports)
+  } else if (name.endsWith('typescript-cjs-hook.cts')) {
+    cjsExports = Object.keys(exports)
+  }
+})
+
+const esm = await import('../fixtures/typescript-hook.mts')
+
+// Types are stripped, so the runtime values load as usual.
+strictEqual(esm.alpha, 1)
+strictEqual(esm.beta, 'two')
+strictEqual(esm.gamma(1), 2)
+strictEqual(typeof esm.Delta, 'function')
+
+// The hook fired, which means iitm wrapped the type-stripped module.
+ok(esmExports, 'expected iitm to instrument the type-stripped .mts module')
+
+// Every value export is captured (including `beta`, the second binding of a
+// type-annotated multi-declarator), while type-only exports are excluded.
+deepStrictEqual(esmExports.slice().sort(), ['Delta', 'alpha', 'beta', 'gamma'])
+
+// The CommonJS sibling format ('commonjs-typescript') is wrapped the same way.
+const cjs = await import('../fixtures/typescript-cjs-hook.cts')
+strictEqual(cjs.default.epsilon, 5)
+strictEqual(cjs.default.zeta({ kind: 'square' }), 'square')
+
+ok(cjsExports, 'expected iitm to instrument the type-stripped .cts module')
+deepStrictEqual(cjsExports.slice().sort(), ['default', 'epsilon', 'module.exports', 'zeta'])
+
+hook.unhook()


### PR DESCRIPTION
## Summary

When `--experimental-strip-types` is active, Node reports `.ts`/`.mts`/`.cts`
files as `module-typescript` / `commonjs-typescript`. Those formats were absent
from `HANDLED_FORMATS`, so the resolve hook returned them uninstrumented — hooks
never fired.

Node hands the `load` hook the original un-stripped source, so the export parser
strips before parsing. The TS formats are added to `HANDLED_FORMATS` only when
`stripTypeScriptTypes` is available (Node >= 22.13), because a static named import
of it throws on older runtimes; runtimes that pre-date the API continue to skip TS
modules instead of crashing.

## Test plan

- [ ] `test/hook/v24-typescript-hook.mjs` covers both `module-typescript` (`.mts`)
  and `commonjs-typescript` (`.cts`); it asserts the hook fires and captures the
  correct export names after type stripping.
- [ ] The test skips automatically below Node v24, so the suite is safe across the
  full version matrix.

Fixes: https://github.com/nodejs/import-in-the-middle/issues/186