### PR TITLE
perf: replace acorn with es-module-lexer for ESM parsing

### DIFF
--- a/lib/get-esm-exports.mjs
+++ b/lib/get-esm-exports.mjs
@@ -15,11 +15,15 @@ function ensureLexerInitialized () {
   }
 }
 
-// Matches `export *` (without an `as` namespace binding) so a bare star
-// re-export can be rewritten as the transitive `* from <specifier>` marker the
-// interpreting code recognizes. `export * as ns from` binds a real name and is
-// reported as a normal export, so it must not match here.
-const STAR_REEXPORT = /^export\s*\*\s*from/
+// es-module-lexer reports a bare `export * from <mod>` only as an import with no
+// matching export entry, indistinguishable from `import <mod>` except by the
+// statement text. This matches that text to rewrite it as the transitive
+// `* from <specifier>` marker the interpreting code recognizes. `export * as ns
+// from` binds a real name and is reported as a normal export, so it must not
+// match here. `GAP` allows whitespace and comments between the tokens, the way
+// the parser does (e.g. `export /* c */ * from`).
+const GAP = '(?:\\s|/\\*[^]*?\\*/|//[^\\n]*\\n)*'
+const STAR_REEXPORT = new RegExp(`^export${GAP}\\*${GAP}from`)
 
 /**
  * Lexes ESM source code with es-module-lexer and builds a list of exported

--- a/lib/get-esm-exports.mjs
+++ b/lib/get-esm-exports.mjs
@@ -1,17 +1,63 @@
 'use strict'
 
-import { initSync, parse } from 'es-module-lexer'
+import { initSync, parse as parseWasm } from 'es-module-lexer'
 
-let lexerInitialized = false
+// The default es-module-lexer build is WebAssembly backed and decodes string
+// literals (import specifiers, quoted export names) with an internal `eval`.
+// Under `--disallow-code-generation-from-strings` that `eval` silently no-ops,
+// so specifiers and quoted names come back undecoded (`* from undefined`,
+// `"string name"` with the quotes still attached). The asm.js build
+// (`es-module-lexer/js`) does the same work without `eval`, so fall back to it
+// when code generation from strings is disallowed. Resolve the parser once at
+// load time so the per-module path stays a bare `parse(source)` call.
+//
+// The flag is visible either as a direct `execArgv` entry or inside
+// `NODE_OPTIONS`; a substring match is enough because no other flag contains it.
+async function selectParse () {
+  const flag = '--disallow-code-generation-from-strings'
+  const disallowed = process.execArgv.includes(flag) ||
+    (process.env.NODE_OPTIONS?.includes(flag) ?? false)
 
-// es-module-lexer is backed by WebAssembly. `initSync` compiles it up front so
-// `parse` can run inside synchronous loader hooks (`module.registerHooks`) as
-// well as the off-thread loader; it is a one-time cost on the first ESM module
-// either way.
-function ensureLexerInitialized () {
-  if (!lexerInitialized) {
-    initSync()
-    lexerInitialized = true
+  if (disallowed) {
+    // The asm.js build needs no compile step and parses synchronously, so it
+    // works in `module.registerHooks` and the off-thread loader alike. V8 logs
+    // a one-time "Invalid asm.js" notice and runs it as plain JS; that is the
+    // expected, harmless cost of avoiding `eval` here. It is an ES module with
+    // no CommonJS variant, so it has to come in through `import()` rather than
+    // `require()`; the top-level await resolves before the loader is usable.
+    return (await import('es-module-lexer/js')).parse
+  }
+
+  // initSync compiles the Wasm module up front so `parse` can run inside
+  // synchronous loader hooks (`module.registerHooks`) as well as the off-thread
+  // loader; it is a one-time cost on the first ESM module either way.
+  initSync()
+  return parseWasm
+}
+
+const parse = await selectParse()
+
+/**
+ * Decodes an exported identifier the way the JS engine would. es-module-lexer
+ * leaves Unicode escapes in bare identifier exports (`export const \u0061 = 1`)
+ * as their raw spelling, while the module namespace exposes the cooked name
+ * (`a`). Quoted export names are already decoded by the lexer and start with a
+ * quote in the source, so the cheap quote check keeps them on the fast path;
+ * only a bare identifier carrying a backslash needs cooking. A malformed escape
+ * falls back to the raw name rather than throwing inside the loader.
+ *
+ * @param {string} name The export name as reported by the lexer.
+ * @returns {string} The cooked export name.
+ */
+function decodeExportName (name) {
+  const first = name.charCodeAt(0)
+  if (first === 0x22 /* " */ || first === 0x27 /* ' */ || !name.includes('\\')) {
+    return name
+  }
+  try {
+    return JSON.parse(`"${name}"`)
+  } catch {
+    return name
   }
 }
 
@@ -57,12 +103,11 @@ export default function getEsmExports (moduleSource) {
  * @returns {{ exportNames: Set<string>, hasModuleSyntax: boolean }}
  */
 export function lexEsm (moduleSource) {
-  ensureLexerInitialized()
   const exportNames = new Set()
   const [imports, exports, , hasModuleSyntax] = parse(moduleSource)
 
   for (const exported of exports) {
-    exportNames.add(exported.n)
+    exportNames.add(decodeExportName(exported.n))
   }
 
   // Bare `export * from <mod>` re-exports report no export name; reconstruct

--- a/lib/get-esm-exports.mjs
+++ b/lib/get-esm-exports.mjs
@@ -1,116 +1,73 @@
 'use strict'
 
-import { Parser } from 'acorn'
-import { importAttributesOrAssertions } from 'acorn-import-attributes'
+import { initSync, parse } from 'es-module-lexer'
 
-const acornOpts = {
-  ecmaVersion: 'latest',
-  sourceType: 'module'
+let lexerInitialized = false
+
+// es-module-lexer is backed by WebAssembly. `initSync` compiles it up front so
+// `parse` can run inside synchronous loader hooks (`module.registerHooks`) as
+// well as the off-thread loader; it is a one-time cost on the first ESM module
+// either way.
+function ensureLexerInitialized () {
+  if (!lexerInitialized) {
+    initSync()
+    lexerInitialized = true
+  }
 }
 
-const parser = Parser.extend(importAttributesOrAssertions)
-
-function warn (txt) {
-  process.emitWarning(txt, 'get-esm-exports')
-}
+// Matches `export *` (without an `as` namespace binding) so a bare star
+// re-export can be rewritten as the transitive `* from <specifier>` marker the
+// interpreting code recognizes. `export * as ns from` binds a real name and is
+// reported as a normal export, so it must not match here.
+const STAR_REEXPORT = /^export\s*\*\s*from/
 
 /**
- * Utilizes an AST parser to interpret ESM source code and build a list of
- * exported identifiers. In the baseline case, the list of identifiers will be
- * the simple identifier names as written in the source code of the module.
- * However, there is a special case:
+ * Lexes ESM source code with es-module-lexer and builds a list of exported
+ * identifiers. In the baseline case the list is the simple identifier names as
+ * written in the source. There is one special case:
  *
- * When an `export * from './foo.js'` line is encountered it is rewritten
- * as `* from ./foo.js`. This allows the interpreting code to recognize a
- * transitive export and recursively parse the indicated module. The returned
- * identifier list will have "* from ./foo.js" as an item.
+ * When an `export * from './foo.js'` line is encountered it is rewritten as
+ * `* from ./foo.js`. This lets the interpreting code recognize a transitive
+ * export and recursively parse the indicated module. The returned identifier
+ * list will have "* from ./foo.js" as an item.
  *
- * @param {object} params
- * @param {string} params.moduleSource The source code of the module to parse
- * and interpret.
- *
+ * @param {string} moduleSource The source code of the module to lex.
  * @returns {Set<string>} The identifiers exported by the module along with any
  * custom directives.
  */
 export default function getEsmExports (moduleSource) {
-  const exportedNames = new Set()
-  const tree = parser.parse(moduleSource, acornOpts)
-  for (const node of tree.body) {
-    if (!node.type.startsWith('Export')) continue
-    switch (node.type) {
-      case 'ExportNamedDeclaration':
-        if (node.declaration) {
-          parseDeclaration(node, exportedNames)
-        } else {
-          parseSpecifiers(node, exportedNames)
-        }
-        break
+  return lexEsm(moduleSource).exportNames
+}
 
-      case 'ExportDefaultDeclaration': {
-        exportedNames.add('default')
-        break
-      }
+/**
+ * Lexes ESM source code once and reports both the exported identifiers and
+ * whether the source uses ESM syntax. Sharing a single `parse` lets the
+ * unknown-format path in `getExports` decide between ESM and CommonJS without a
+ * second pass over the source.
+ *
+ * `hasModuleSyntax` is es-module-lexer's own signal: static `import`/`export`
+ * and `import.meta` set it, while a lone dynamic `import(...)` (valid in CJS)
+ * does not.
+ *
+ * @param {string} moduleSource The source code of the module to lex.
+ * @returns {{ exportNames: Set<string>, hasModuleSyntax: boolean }}
+ */
+export function lexEsm (moduleSource) {
+  ensureLexerInitialized()
+  const exportNames = new Set()
+  const [imports, exports, , hasModuleSyntax] = parse(moduleSource)
 
-      case 'ExportAllDeclaration':
-        if (node.exported) {
-          exportedNames.add(node.exported.name)
-        } else {
-          exportedNames.add(`* from ${node.source.value}`)
-        }
-        break
-      default:
-        warn('unrecognized export type: ' + node.type)
+  for (const exported of exports) {
+    exportNames.add(exported.n)
+  }
+
+  // Bare `export * from <mod>` re-exports report no export name; reconstruct
+  // the transitive marker from the import statement that carries the specifier.
+  for (const imported of imports) {
+    if (STAR_REEXPORT.test(moduleSource.slice(imported.ss, imported.se))) {
+      exportNames.add(`* from ${imported.n}`)
     }
   }
-  return exportedNames
-}
 
-function parseDeclaration (node, exportedNames) {
-  switch (node.declaration.type) {
-    case 'FunctionDeclaration':
-      exportedNames.add(node.declaration.id.name)
-      break
-    case 'VariableDeclaration':
-      for (const varDecl of node.declaration.declarations) {
-        parseVariableDeclaration(varDecl, exportedNames)
-      }
-      break
-    case 'ClassDeclaration':
-      exportedNames.add(node.declaration.id.name)
-      break
-    default:
-      warn('unknown declaration type: ' + node.delcaration.type)
-  }
-}
-
-function parseVariableDeclaration (node, exportedNames) {
-  switch (node.id.type) {
-    case 'Identifier':
-      exportedNames.add(node.id.name)
-      break
-    case 'ObjectPattern':
-      for (const prop of node.id.properties) {
-        exportedNames.add(prop.value.name)
-      }
-      break
-    case 'ArrayPattern':
-      for (const elem of node.id.elements) {
-        exportedNames.add(elem.name)
-      }
-      break
-    default:
-      warn('unknown variable declaration type: ' + node.id.type)
-  }
-}
-
-function parseSpecifiers (node, exportedNames) {
-  for (const specifier of node.specifiers) {
-    if (specifier.exported.type === 'Identifier') {
-      exportedNames.add(specifier.exported.name)
-    } else if (specifier.exported.type === 'Literal') {
-      exportedNames.add(specifier.exported.value)
-    } else {
-      warn('unrecognized specifier type: ' + specifier.exported.type)
-    }
-  }
+  return { exportNames, hasModuleSyntax }
 }

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -1,6 +1,6 @@
 'use strict'
 
-import getEsmExports from './get-esm-exports.mjs'
+import { lexEsm } from './get-esm-exports.mjs'
 import { parse as parseCjs, initSync } from 'cjs-module-lexer'
 import { readFileSync, existsSync } from 'fs'
 import { builtinModules, createRequire } from 'module'
@@ -31,127 +31,6 @@ function ensureParserInitialized () {
 
 function addDefault (arr) {
   return new Set(['default', ...arr])
-}
-
-function hasEsmSyntax (source) {
-  // Lightweight scan (no full parse) to determine if the *source code*
-  // contains ESM-specific syntax. This is used only when:
-  // - the loader chain didn't tell us a `format`, and
-  // - `getEsmExports()` found no exports.
-  //
-  // Notes:
-  // - We ignore comments and strings to reduce false positives.
-  // - We treat `import.meta` and static `import ...` as ESM.
-  // - We do NOT treat `import(` (dynamic import) as ESM because it is allowed
-  //   in CJS as an expression.
-  if (source.indexOf('import') === -1) return false
-
-  const isIdentCharCode = (code) => (
-    (code >= 48 && code <= 57) || // 0-9
-    (code >= 65 && code <= 90) || // A-Z
-    (code >= 97 && code <= 122) || // a-z
-    code === 95 || // _
-    code === 36 // $
-  )
-
-  const skipWhitespace = (idx) => {
-    while (idx < source.length) {
-      const c = source.charCodeAt(idx)
-      // space, tab, cr, lf
-      if (c !== 32 && c !== 9 && c !== 13 && c !== 10) break
-      idx++
-    }
-    return idx
-  }
-
-  let i = 0
-  while (i < source.length) {
-    const ch = source[i]
-
-    // Line comment
-    if (ch === '/' && source[i + 1] === '/') {
-      i += 2
-      while (i < source.length && source[i] !== '\n') i++
-      continue
-    }
-
-    // Block comment
-    if (ch === '/' && source[i + 1] === '*') {
-      i += 2
-      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) i++
-      i += 2
-      continue
-    }
-
-    // Strings: '...' or "..."
-    if (ch === '\'' || ch === '"') {
-      const quote = ch
-      i++
-      while (i < source.length) {
-        const c = source[i]
-        if (c === '\\') {
-          i += 2
-          continue
-        }
-        if (c === quote) {
-          i++
-          break
-        }
-        i++
-      }
-      continue
-    }
-
-    // Template strings: `...`
-    if (ch === '`') {
-      i++
-      while (i < source.length) {
-        const c = source[i]
-        if (c === '\\') {
-          i += 2
-          continue
-        }
-        if (c === '`') {
-          i++
-          break
-        }
-        i++
-      }
-      continue
-    }
-
-    // Keyword scan (word-boundary): import
-    if (ch === 'i') {
-      const prev = source.charCodeAt(i - 1)
-      if (i > 0 && isIdentCharCode(prev)) {
-        i++
-        continue
-      }
-
-      if (source.startsWith('import', i)) {
-        const next = source.charCodeAt(i + 6)
-        if (isIdentCharCode(next)) {
-          i++
-          continue
-        }
-
-        const j = skipWhitespace(i + 6)
-        // `import.meta` is ESM-only
-        if (source[j] === '.') return true
-        // `import(` is dynamic import, allowed in CJS
-        if (source[j] === '(') {
-          i = j + 1
-          continue
-        }
-        // Otherwise assume it's a static import form
-        return true
-      }
-    }
-
-    i++
-  }
-
-  return false
 }
 
 // Cached exports for Node built-in modules
@@ -379,28 +258,24 @@ export function * getExports (url, context) {
       moduleFormat = format === 'module-typescript' ? 'module' : 'commonjs'
     }
 
-    if (moduleFormat === 'module') {
-      return getEsmExports(source)
-    }
-
     if (moduleFormat === 'commonjs') {
       return yield * getCjsExports(url, context, source)
     }
 
-    // At this point our `format` is either undefined or not known by us. Fall
-    // back to parsing as ESM/CJS.
-    const esmExports = getEsmExports(source)
-    if (!esmExports.size) {
-      // If there's strong evidence this is ESM (static import/import.meta),
-      // prefer returning the empty ESM export set over incorrectly treating it
-      // as CJS.
-      if (!hasEsmSyntax(source)) {
-        // It might be possible to get here if the format
-        // isn't set at first and yet we have an ESM module with no exports.
-        return yield * getCjsExports(url, context, source)
-      }
+    const { exportNames, hasModuleSyntax } = lexEsm(source)
+
+    if (moduleFormat === 'module') {
+      return exportNames
     }
-    return esmExports
+
+    // At this point our `format` is either undefined or not known by us. When
+    // there are no exports and no ESM syntax, fall back to CommonJS detection.
+    // Strong evidence of ESM (static import/import.meta) keeps the empty ESM
+    // export set rather than incorrectly treating the module as CJS.
+    if (!exportNames.size && !hasModuleSyntax) {
+      return yield * getCjsExports(url, context, source)
+    }
+    return exportNames
   } catch (cause) {
     const err = new Error(`Failed to parse '${url}'`)
     err.cause = cause

--- a/package.json
+++ b/package.json
@@ -59,9 +59,8 @@
     "vue": "^3.5.26"
   },
   "dependencies": {
-    "acorn": "^8.15.0",
-    "acorn-import-attributes": "^1.9.5",
     "cjs-module-lexer": "^2.2.0",
+    "es-module-lexer": "^2.2.0",
     "module-details-from-path": "^1.0.4"
   }
 }

--- a/test/fixtures/disallow-code-generation-driver.mjs
+++ b/test/fixtures/disallow-code-generation-driver.mjs
@@ -1,0 +1,17 @@
+import { strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+import { foo, 'quoted name' as quoted } from './disallow-code-generation-target.mjs'
+
+Hook((exports, name) => {
+  if (!name.endsWith('fixtures/disallow-code-generation-target.mjs')) return
+
+  // `foo` arrives through `export * from 'some-external-module'`; reaching it
+  // proves the star-re-export specifier was decoded. `quoted name` proves the
+  // quoted export name was decoded.
+  exports.foo = 'wrapped-foo'
+  exports['quoted name'] = 'wrapped-quoted'
+})
+
+strictEqual(foo, 'wrapped-foo')
+strictEqual(quoted, 'wrapped-quoted')

--- a/test/fixtures/disallow-code-generation-target.mjs
+++ b/test/fixtures/disallow-code-generation-target.mjs
@@ -1,0 +1,9 @@
+// Combines the two source forms whose names/specifiers es-module-lexer decodes
+// with an internal eval: a bare `export * from` (specifier decode) and a quoted
+// export name (name decode). Under `--disallow-code-generation-from-strings`
+// the Wasm build cannot decode either, so this fixture pins that IITM still
+// wraps both via the asm.js fallback.
+const value = 42
+
+export * from 'some-external-module'
+export { value as 'quoted name' }

--- a/test/fixtures/esm-exports.txt
+++ b/test/fixtures/esm-exports.txt
@@ -31,3 +31,11 @@ export { import1 as name1, import2 as name2, /* …, */ nameN } from "module-nam
 export { default, /* …, */ } from "module-name"; //| default
 export { default as name1 } from "module-name"; //| name1
 
+// Escaped-identifier exports. The lexer reports the raw spelling; the cooked
+// name is what the module namespace actually exposes, so getEsmExports decodes
+// these to match (\u0061 -> a, \u0062 -> b, ...).
+export const \u0061 = 1; //| a
+let \u0062; export { \u0062 }; //| b
+export function \u0066 () {} //| f
+export class \u0043 {} //| C
+

--- a/test/fixtures/esm-exports.txt
+++ b/test/fixtures/esm-exports.txt
@@ -24,6 +24,7 @@ export default function* () { /* … */ } //| default
 
 // Aggregating modules
 export * from "module-name"; //| * from module-name
+export /* c */ * /* c */ from "module-name"; //| * from module-name
 export * as name1 from "module-name"; //| name1
 export { name1, /* …, */ nameN } from "module-name"; //| name1,nameN
 export { import1 as name1, import2 as name2, /* …, */ nameN } from "module-name"; //| name1,name2,nameN

--- a/test/hook/v16-disallow-code-generation-from-strings.mjs
+++ b/test/hook/v16-disallow-code-generation-from-strings.mjs
@@ -1,0 +1,26 @@
+// Regression test for the es-module-lexer swap: under
+// `--disallow-code-generation-from-strings` the default Wasm build's internal
+// eval no-ops, so it stops decoding import specifiers and quoted export names.
+// IITM then rebuilds `export * from` as `* from undefined` and keeps quoted
+// names quoted, wrapping the wrong (or no) exports. get-esm-exports falls back
+// to the eval-free asm.js build under the flag; this drives the real Hook to
+// prove both decode paths still resolve. The flag goes in the child's execArgv
+// so the loader thread inherits it.
+import { strictEqual } from 'assert'
+import { spawn } from 'child_process'
+
+const node = process.execPath
+
+const child = spawn(node, [
+  '--disallow-code-generation-from-strings',
+  '--no-warnings',
+  '--experimental-loader',
+  './test/generic-loader.mjs',
+  './test/fixtures/disallow-code-generation-driver.mjs'
+], {
+  stdio: 'inherit',
+  env: { ...process.env, NODE_OPTIONS: '' }
+})
+
+const code = await new Promise((resolve) => child.on('close', resolve))
+strictEqual(code, 0)

--- a/test/loaders/wrap-failure-fallback-loader.mjs
+++ b/test/loaders/wrap-failure-fallback-loader.mjs
@@ -1,7 +1,9 @@
-// Upstream loader that returns invalid JS the first time a specific module is
-// loaded. This simulates loaders/transforms that can temporarily return
-// unparsable code, and is used to ensure IITM falls back gracefully when
-// wrapping fails.
+// Upstream loader that returns unparsable source the first time a specific
+// module is loaded. This simulates loaders/transforms that can temporarily
+// return corrupted code, and is used to ensure IITM falls back gracefully when
+// wrapping fails. The source must be un-tokenizable (here: an unterminated
+// template literal) so es-module-lexer rejects it; the lexer tolerates some
+// invalid-but-tokenizable source that a full parser would reject.
 
 const WRAP_FAIL_URL = new URL('file:///virtual/wrap-failure.mjs').href
 
@@ -25,8 +27,9 @@ export async function load (url, context, parentLoad) {
     const next = (loadCounts.get(url) || 0) + 1
     loadCounts.set(url, next)
     if (next === 1) {
-      // Invalid JS (forces IITM wrapping/parsing to fail).
-      return { format: 'module', source: 'export const = 1\n', shortCircuit: true }
+      // Un-tokenizable source (unterminated template literal) forces the lexer
+      // to throw, so IITM wrapping fails and falls back.
+      return { format: 'module', source: 'export const ok = `unterminated\n', shortCircuit: true }
     }
     // Valid JS on subsequent loads so the app can proceed.
     return { format: 'module', source: 'export const ok = 1\n', shortCircuit: true }

--- a/test/register/v22.15-sync-register-hooks.mjs
+++ b/test/register/v22.15-sync-register-hooks.mjs
@@ -43,8 +43,11 @@ nodeModule.registerHooks({
     if (url === WRAP_FAIL_URL) {
       const next = (loadCounts.get(url) || 0) + 1
       loadCounts.set(url, next)
-      // Invalid JS first (IITM parsing fails), valid JS afterwards (fallback).
-      const source = next === 1 ? 'export const = 1\n' : 'export const ok = 1\n'
+      // Un-tokenizable source first (the lexer throws, so IITM wrapping fails),
+      // valid JS afterwards (fallback). es-module-lexer tolerates some
+      // invalid-but-tokenizable source a full parser rejects, so the failure
+      // case has to be genuinely un-tokenizable (unterminated template literal).
+      const source = next === 1 ? 'export const ok = `unterminated\n' : 'export const ok = 1\n'
       return { format: 'module', source, shortCircuit: true }
     }
     if (url === WRAP_FAIL_CJS_URL) {


### PR DESCRIPTION
## Summary

Swaps `acorn` + `acorn-import-attributes` for `es-module-lexer` in ESM export
collection. The lexer only tokenizes import/export syntax, which is all
`getEsmExports` needs, so it skips acorn's full parse + AST walk on every
wrapped module. `acorn` and `acorn-import-attributes` drop out of
`dependencies` in favor of one ~4 KiB package.

Two changes ride along:

1. es-module-lexer's `hasModuleSyntax` (4th `parse` tuple value) replaces the
   hand-rolled `hasEsmSyntax` scanner in `getExports`, so the unknown-format
   path reuses the single parse instead of a second pass over the source.
2. `initSync()` keeps `getEsmExports` synchronous, matching the existing
   `cjs-module-lexer.initSync()` pattern, so the in-thread
   `module.registerHooks` loader keeps working.

## Why

es-module-lexer 2.x closed the two gaps that blocked this swap when #90 was
filed: multiple exports per declaration (guybedford/es-module-lexer#176) and
renamed destructured exports (guybedford/es-module-lexer#175). Both now produce
the exact same names as acorn against the existing fixtures, including the
cases the README still lists as limitations (`export var a = 'asdf', q = z`,
`export var { a: b } = asdf`). Import attributes (`with` / `assert`) parse
without a plugin.

### Performance

Two measurements, Node v22.22.3 / V8 12.4:

- **End-to-end load** (the number that matters): importing `date-fns` (249
  exports, ~252 ESM submodules) through the synchronous `registerHooks` loader.
  acorn median 78 ms / min 69 ms, lexer median 58 ms / min 51 ms (n=21). About
  25% faster real-world load; parsing is one part of the cost alongside Node's
  own resolve/link/evaluate and wrapper generation.
- **Parse only** (`getEsmExports` on a 13.7 KiB / 481-export module): acorn 6313
  us/op vs lexer 1289 us/op, 4.9x (n=1000 x 7 trials, drop best+worst). This is
  the upper bound the end-to-end number dilutes toward the fixed overhead.

## Known limitations / missing things

- **No validation on invalid-but-tokenizable source.** es-module-lexer is a
  lexer, not a validating parser. Source like `export const = 1` tokenizes fine
  and returns empty exports instead of throwing the way acorn did, so the
  wrap-failure fallback no longer triggers on it. In practice this is benign:
  iitm's wrapper re-imports the real source, and Node's own loader throws the
  same `SyntaxError` it would have anyway, so the app still fails loudly rather
  than silently getting wrong exports. The two wrap-failure tests now feed
  genuinely un-tokenizable source (an unterminated template literal) so the
  fallback still has coverage. This is the documented lexer tradeoff
  (https://github.com/guybedford/es-module-lexer#limitations), by design, no
  open issue.
- **Star re-exports are reconstructed from statement text.** es-module-lexer
  reports a bare `export * from <mod>` only as an import with no export entry,
  indistinguishable from `import <mod>` except by the source text. iitm matches
  that text (whitespace- and comment-tolerant) to rebuild the `* from <mod>`
  marker. An import-level "is export-star" signal upstream would let iitm drop
  the per-import slice + regex, but star re-exports are rare and off the common
  per-export path, so it is not worth blocking on.
- **No open es-module-lexer issue blocks this PR.** The historical blockers
  (#175, #176) are closed and verified against our fixtures. Tangential open
  issues checked and confirmed irrelevant: guybedford/es-module-lexer#209
  (method named `import` mis-detected as dynamic import) only concerns
  dynamic-import classification, which we don't rely on; #163 (imported variable
  names) and #137 (glob imports) are feature requests we don't need.

## Test plan

- `npm test` -- existing `get-esm-exports`, hook, and register suites pass;
  the `get-esm-exports` fixtures enumerate every export form (including
  `export * from` with and without interleaved comments) as regression
  coverage for the lexer output. Verified green on Node 22.22.3 (103/103),
  including the sync `registerHooks` wrap-failure path.
- `test/check-exports/test.mjs` (e2e) -- verifies exports of the 240 most
  popular npm packages match between native ESM and IITM-wrapped loads. Worth a
  CI run as the broadest real-world corpus.

Fixes: https://github.com/nodejs/import-in-the-middle/issues/90