### PR TITLE
fix: guard against circular export-star recursion

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -20,6 +20,9 @@ extends:
 ignorePatterns:
   - test/fixtures/circular-a.js
   - test/fixtures/circular-b.js
+  - test/fixtures/circular-star-a.mjs
+  - test/fixtures/circular-star-b.mjs
+  - test/fixtures/self-star-reexport.mjs
   - test/fixtures/reexport.js
   - test/fixtures/duplicate-explicit.mjs
   - test/fixtures/duplicate.mjs

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -14,6 +14,13 @@ import { RESOLVE, driveSync, driveAsync } from './lib/io.mjs'
 const specifiers = new Map()
 const isWin = process.platform === 'win32'
 
+// Depth at which `processModule` starts tracking visited URLs to break an
+// `export *` cycle. Real re-export chains are only a few levels deep, so this
+// is far beyond any legitimate graph yet well below the call-stack limit a
+// cycle would otherwise hit. Below it the recursion pays only an integer
+// compare per level and allocates no set.
+const STAR_CYCLE_DEPTH = 100
+
 // FIXME: Typescript extensions are added temporarily until we find a better
 // way of supporting arbitrary extensions
 const EXTENSION_RE = /\.(js|mjs|cjs|ts|mts|cts)$/
@@ -271,12 +278,20 @@ function buildSetter (n, srcUrl) {
  * @param {string} params.srcUrl The full URL to the module to process.
  * @param {object} params.context Provided by the loaders API.
  * @param {boolean} [params.excludeDefault = false] Exclude the default export.
+ * @param {number} [params.depth = 0] Star-re-export recursion depth. Used to
+ * detect `export *` cycles (`a` re-exports `b`, `b` re-exports `a`) cheaply:
+ * the acyclic common case pays only an integer compare per level, and the
+ * cycle-tracking set is allocated only once recursion is implausibly deep.
+ * @param {Set<string>} [params.seen] URLs currently on the recursion stack,
+ * created lazily once `depth` crosses {@link STAR_CYCLE_DEPTH}. A URL is added
+ * before descending into its subtree and removed once that subtree finishes, so
+ * it tracks the active path rather than every URL ever visited.
  *
  * @returns {Generator<Array, Map<string, string>>} A generator that yields I/O
  * operations and ultimately returns the shimmed setters for all the exports
  * from the module and any transitive export all modules.
  */
-function * processModule ({ srcUrl, context, excludeDefault = false }) {
+function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen }) {
   const exportNames = yield * getExports(srcUrl, context)
   const starExports = new Set()
   const setters = new Map()
@@ -330,14 +345,36 @@ function * processModule ({ srcUrl, context, excludeDefault = false }) {
       // parent's `format` to know if this sub-module is ESM or CJS!
       const result = yield [RESOLVE, newSpecifier, { parentURL: srcUrl }]
 
-      const subSetters = yield * processModule({
-        srcUrl: result.url,
-        context: { ...context, format: result.format },
-        excludeDefault: true
-      })
+      // `export *` graphs are normally only a handful of levels deep. A cycle
+      // (`a` re-exports `b`, `b` re-exports `a`) instead recurses without bound
+      // and exhausts memory. Rather than track every URL on the common shallow
+      // path, only start recording once the depth is implausibly large for a
+      // real graph; from there a re-export pointing back at a module already on
+      // the recursion stack is the cycle, and is skipped (its exports are
+      // collected by the in-progress ancestor frame). `seen` mirrors the stack,
+      // not every URL visited: a module reached and fully processed through one
+      // sibling branch must stay reachable through a later, more direct branch,
+      // so it is removed again once its subtree finishes.
+      if (depth >= STAR_CYCLE_DEPTH) {
+        seen ??= new Set()
+        if (seen.has(result.url)) continue
+        seen.add(result.url)
+      }
 
-      for (const [name, setter] of subSetters.entries()) {
-        addSetter(name, setter, true)
+      try {
+        const subSetters = yield * processModule({
+          srcUrl: result.url,
+          context: { ...context, format: result.format },
+          excludeDefault: true,
+          depth: depth + 1,
+          seen
+        })
+
+        for (const [name, setter] of subSetters.entries()) {
+          addSetter(name, setter, true)
+        }
+      } finally {
+        seen?.delete(result.url)
       }
     } else {
       addSetter(n, buildSetter(n, srcUrl))

--- a/test/fixtures/circular-star-a.mjs
+++ b/test/fixtures/circular-star-a.mjs
@@ -1,0 +1,3 @@
+export * from './circular-star-b.mjs'
+
+export const fromA = 1

--- a/test/fixtures/circular-star-b.mjs
+++ b/test/fixtures/circular-star-b.mjs
@@ -1,0 +1,3 @@
+export * from './circular-star-a.mjs'
+
+export const fromB = 2

--- a/test/fixtures/self-star-reexport.mjs
+++ b/test/fixtures/self-star-reexport.mjs
@@ -1,0 +1,7 @@
+// The exact shape from the original report: a module whose `export *` points at
+// itself (https://github.com/platformatic/kafka/pull/191 removed an
+// `export * from './index.ts'`). Without the cycle guard this re-enters
+// processModule on the same URL forever.
+export * from './self-star-reexport.mjs'
+
+export const fromSelf = 1

--- a/test/hook/circular-star-reexport.mjs
+++ b/test/hook/circular-star-reexport.mjs
@@ -1,0 +1,13 @@
+import { fromA, fromB } from '../fixtures/circular-star-a.mjs'
+import Hook from '../../index.js'
+import { strictEqual } from 'assert'
+
+Hook((exports, name) => {
+  if (name.match(/circular-star-[ab].mjs/)) {
+    exports.fromA &&= exports.fromA + 10
+    exports.fromB &&= exports.fromB + 10
+  }
+})
+
+strictEqual(fromA, 11)
+strictEqual(fromB, 12)

--- a/test/hook/self-star-reexport.mjs
+++ b/test/hook/self-star-reexport.mjs
@@ -1,0 +1,11 @@
+import { fromSelf } from '../fixtures/self-star-reexport.mjs'
+import Hook from '../../index.js'
+import { strictEqual } from 'assert'
+
+Hook((exports, name) => {
+  if (name.endsWith('self-star-reexport.mjs')) {
+    exports.fromSelf &&= exports.fromSelf + 10
+  }
+})
+
+strictEqual(fromSelf, 11)


### PR DESCRIPTION
## Summary

A module graph with a cyclic `export *` (`a` re-exports `b`, `b` re-exports `a`, or a module re-exporting itself) made `processModule` recurse on the star-export line without bound. On Node 24 it spins and grows memory until the process is killed (the hang in #245); on Node 22 it hits the V8 stack limit, acorn surfaces it as a parse failure, and the module loads unwrapped so the hook silently never applies.

The fix tracks the URLs currently on the recursion stack and skips a star re-export that points back at one of them, since its named exports are already collected by the in-progress ancestor frame. The set is the active path, not every URL ever visited: a URL is added before descending into its subtree and removed once that subtree finishes. Keeping it path-scoped matters in a graph deeper than the guard threshold, where a module reached through one sibling `export *` branch must stay reachable through a later, more direct branch (native ESM still resolves it there). Tracking only starts once the depth is implausibly large for a real graph, so the acyclic common case allocates nothing and pays one integer compare per level.

## Test plan

- `test/hook/circular-star-reexport.mjs` covers a two-module `export *` cycle; it hangs / never applies the hook on `main` and passes with the fix.
- `test/hook/self-star-reexport.mjs` covers the original report's shape, a module whose `export *` points at itself.
- Verified `npm run lint` and both tests on Node 24.16.0 (and the cycle behavior on 22.22.0).

Fixes: https://github.com/nodejs/import-in-the-middle/issues/245