### PR TITLE
fix: resolve re-exported values from their defining module

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -28,3 +28,5 @@ ignorePatterns:
   - test/fixtures/duplicate.mjs
   - test/fixtures/export-types/default-call-expression-renamed.mjs
   - test/fixtures/reexport-same-source.mjs
+  - test/fixtures/reexport-explicit-override.mjs
+  - test/fixtures/reexport-nested-agg.mjs

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -27,3 +27,4 @@ ignorePatterns:
   - test/fixtures/duplicate-explicit.mjs
   - test/fixtures/duplicate.mjs
   - test/fixtures/export-types/default-call-expression-renamed.mjs
+  - test/fixtures/reexport-same-source.mjs

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -195,11 +195,21 @@ function emitWarning (err) {
  * of how the loader is driven, so both the synchronous and asynchronous paths
  * share it.
  *
+ * The value is read from `namespaceVar`, the wrapper's namespace binding for the
+ * module that *defines* the export. For a module's own exports that is the
+ * wrapped module itself; for a name re-exported through `export *` it is the
+ * leaf that declares it. Reading from the defining module rather than the
+ * aggregating one keeps the value resolvable when the same binding reaches the
+ * aggregator through more than one re-export chain — Node sees those chains as
+ * distinct wrapper modules and leaves the name ambiguous (hence `undefined`) on
+ * the aggregate namespace, while the defining module always holds it (#171).
+ *
  * @param {string} n The exported name.
  * @param {string} srcUrl The URL of the module the export belongs to.
+ * @param {string} namespaceVar The wrapper binding holding `srcUrl`'s namespace.
  * @returns {string}
  */
-function buildSetter (n, srcUrl) {
+function buildSetter (n, srcUrl, namespaceVar) {
   const variableName = `$${n.replace(/[^a-zA-Z0-9_$]/g, '_')}`
   const objectKey = JSON.stringify(n)
   const reExportedName = n === 'default' ? n : objectKey
@@ -214,7 +224,7 @@ function buildSetter (n, srcUrl) {
     : `export { ${variableName} as ${reExportedName} }`
 
   return `let ${variableName}
-__bind(${objectKey}, v => { ${variableName} = v }, () => ${variableName}${fallback})
+__bind(${objectKey}, ${namespaceVar}, v => { ${variableName} = v }, () => ${variableName}${fallback})
 ${reExportLine}`
 }
 
@@ -240,56 +250,73 @@ ${reExportLine}`
  * created lazily once `depth` crosses {@link STAR_CYCLE_DEPTH}. A URL is added
  * before descending into its subtree and removed once that subtree finishes, so
  * it tracks the active path rather than every URL ever visited.
+ * @param {Map<string, string>} [params.originNamespaces] Shared registry mapping
+ * a defining-module URL to the wrapper namespace alias a same-origin `export *`
+ * collision must read it from. Absent until the first such collision; then
+ * threaded through the recursion so one defining module yields one alias and
+ * {@link buildWrapperSource} imports each once. Only `*`-collided names use it;
+ * every other export reads from the wrapped module's own `namespace`.
  *
- * @returns {Generator<Array, { setters: Map<string, string>, origins: (Map<string, string> | undefined) }>}
+ * @returns {Generator<Array, { setters: Map<string, string>, origins: (Map<string, string> | undefined), originNamespaces: (Map<string, string> | undefined) }>}
  * A generator that yields I/O operations and ultimately returns the shimmed
  * setters for all the exports from the module and any transitive export all
- * modules, plus the module each `*`-sourced name was defined in. `origins` lets
- * a caller tell a genuinely ambiguous `export *` collision (same name from two
- * different modules) apart from the same binding reached through more than one
- * re-export path; it is `undefined` for a module with no `export *`.
+ * modules. `origins` (the defining module per `*`-sourced name) is `undefined`
+ * for a module with no `export *`; `originNamespaces` stays `undefined` unless a
+ * same-origin `*` collision actually needed an alias.
  */
-function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen }) {
+function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen, originNamespaces }) {
   const exportNames = yield * getExports(srcUrl, context)
   const setters = new Map()
 
-  // The dedup bookkeeping only matters once a `*` re-export collides with a name
-  // already present, so it stays unallocated for the common module whose names
-  // are all distinct. `starExports` records which live names came from a `*`
-  // re-export (so an explicit export can override them); `starOrigins` records
-  // the defining module of each `*`-sourced name, so two `*` re-exports of the
-  // same name can be told apart.
-  let starExports
+  // Maps each live `*`-sourced name to the module that defined it. Its keys
+  // double as "this name came from a `*` re-export" (so an explicit export can
+  // override it), and its values let two `*` re-exports of the same name be told
+  // apart. Allocated on the first `export *`, never for a module without one; a
+  // single Map carries both facts so a star with no collision pays one structure
+  // and one write per name, not two.
   let starOrigins
+
+  // A name pulled in through more than one `export *` chain that all bottom out
+  // at the same module stays exported (ECMAScript ResolveExport;
+  // tc39/ecma262#3715), but the *aggregate* namespace this wrapper imports drops
+  // it: under iitm the chains are distinct wrapped modules, so Node sees the
+  // re-export as ambiguous and the name reads back undefined. Only those names
+  // must instead read from their defining module's own namespace, which always
+  // holds the value. `originNamespaces` maps such a defining module to the alias
+  // the wrapper imports for it; it is allocated on the first surviving
+  // collision, so a module without one emits no extra import (#171).
+  const ensureOriginNamespace = (origin) => {
+    originNamespaces ??= new Map()
+    let alias = originNamespaces.get(origin)
+    if (alias === undefined) {
+      alias = `__ns${originNamespaces.size}`
+      originNamespaces.set(origin, alias)
+    }
+    return alias
+  }
 
   const addSetter = (name, setter, isStarExport, origin) => {
     if (setters.has(name)) {
       if (isStarExport) {
-        // A `*` re-export collides with an existing `*` re-export. Per
-        // ECMAScript ResolveExport this is ambiguous and excluded only when the
-        // two name the same export from *different* modules; the same binding
-        // reached through two re-export chains resolves to one module and stays
-        // exported (tc39/ecma262#3715). Keep it only when the origins match.
-        if (starExports.has(name)) {
-          if (starOrigins.get(name) !== origin) {
+        // `starOrigins.has(name)` means the existing entry also came from a `*`
+        // re-export (an explicit export would not be tracked here).
+        if (starOrigins.has(name)) {
+          if (starOrigins.get(name) === origin) {
+            // The same binding reached through two `*` re-export chains. It
+            // stays exported, but the aggregate namespace dropped it, so point
+            // its setter at the defining module's namespace instead.
+            setters.set(name, buildSetter(name, origin, ensureOriginNamespace(origin)))
+          } else {
+            // Genuinely ambiguous: two `*` re-exports name it from different
+            // modules. Per ResolveExport the name is excluded entirely.
             setters.delete(name)
-            starExports.delete(name)
             starOrigins.delete(name)
           }
         }
         // An explicit export already shadows the `*` re-export; leave it.
-        return
-      }
-
-      // An explicit named export overrides a `*` re-export of the same name.
-      if (starExports !== undefined && starExports.has(name)) {
-        starExports.delete(name)
-        starOrigins.delete(name)
-        setters.set(name, setter)
       }
     } else {
       if (isStarExport) {
-        starExports.add(name)
         starOrigins.set(name, origin)
       }
 
@@ -319,9 +346,7 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
       // parent's `format` to know if this sub-module is ESM or CJS!
       const result = yield [RESOLVE, newSpecifier, { parentURL: srcUrl }]
 
-      // First `*` re-export: allocate the dedup bookkeeping lazily so a module
-      // without one pays nothing.
-      starExports ??= new Set()
+      // First `*` re-export: allocate the origin bookkeeping lazily.
       starOrigins ??= new Map()
 
       // `export *` graphs are normally only a handful of levels deep. A cycle
@@ -346,21 +371,31 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
           context: { ...context, format: result.format },
           excludeDefault: true,
           depth: depth + 1,
-          seen
+          seen,
+          originNamespaces
         })
 
-        for (const [name, setter] of sub.setters.entries()) {
+        // Adopt any registry a nested `export *` minted before processing this
+        // child's results, so a collision detected here extends the same Map the
+        // child's setters already reference (one alias per defining module across
+        // the whole tree) rather than orphaning the child's into a second Map.
+        originNamespaces ??= sub.originNamespaces
+
+        // Star targets build their setters against `namespace` like any other
+        // module; only a surviving same-origin collision (in addSetter) rewrites
+        // the affected name to read from its defining module's alias.
+        for (const [name, setter] of sub.setters) {
           addSetter(name, setter, true, sub.origins?.get(name) ?? result.url)
         }
       } finally {
         seen?.delete(result.url)
       }
     } else {
-      addSetter(n, buildSetter(n, srcUrl), false)
+      addSetter(n, buildSetter(n, srcUrl, 'namespace'), false)
     }
   }
 
-  return { setters, origins: starOrigins }
+  return { setters, origins: starOrigins, originNamespaces }
 }
 
 function addIitm (url) {
@@ -602,11 +637,23 @@ export function createHook (meta) {
   // Builds the wrapper module source that re-exports the real module through
   // iitm's proxy. Pure string generation shared by the asynchronous and
   // synchronous `load` paths.
-  function buildWrapperSource (realUrl, setters, originalSpecifier) {
+  function buildWrapperSource (realUrl, setters, originalSpecifier, originNamespaces) {
+    // The wrapped module imports its namespace as `namespace`, which serves
+    // every export but the ones a same-origin `export *` collision forced onto
+    // their defining module (#171): the aggregate namespace drops those as
+    // ambiguous under iitm, so each such defining module gets its own alias the
+    // wrapper imports. Absent the registry (no such collision) nothing is added.
+    let originImports = ''
+    if (originNamespaces !== undefined) {
+      for (const [originUrl, alias] of originNamespaces) {
+        originImports += `import * as ${alias} from ${JSON.stringify(originUrl)}\n`
+      }
+    }
+
     return `
 import { register } from '${iitmURL}'
 import * as namespace from ${JSON.stringify(realUrl)}
-
+${originImports}
 // Mimic a Module object (https://tc39.es/ecma262/#sec-module-namespace-objects).
 const _ = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })
 const set = {}
@@ -641,10 +688,10 @@ function __flushPendingOnce () {
   __pending = next
 }
 
-function __bind (key, write, read, useFallback) {
+function __bind (key, source, write, read, useFallback) {
   const readSource = useFallback
-    ? () => namespace[key] ?? namespace['default']
-    : () => namespace[key]
+    ? () => source[key] ?? source['default']
+    : () => source[key]
   __overridden[key] = false
   let deferred = false
   try {
@@ -703,13 +750,13 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
   // succeeds: free the specifier entry early, and remember CJS modules so their
   // transitive require() chain bypasses iitm (see `load`). Returns the wrapper
   // module source.
-  function onWrapSuccess (realUrl, context, originalSpecifier, setters) {
+  function onWrapSuccess (realUrl, context, originalSpecifier, setters, originNamespaces) {
     specifiers.delete(realUrl)
     // context.format is set to 'commonjs' by getCjsExports during processModule.
     if (context.format === 'commonjs') {
       cjsInIitmChain.add(realUrl)
     }
-    return buildWrapperSource(realUrl, setters, originalSpecifier)
+    return buildWrapperSource(realUrl, setters, originalSpecifier, originNamespaces)
   }
 
   // Bookkeeping shared by the async and sync wrap paths when `processModule`
@@ -730,11 +777,11 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
       const originalSpecifier = specifiers.get(realUrl)
 
       try {
-        const { setters } = await driveAsync(
+        const { setters, originNamespaces } = await driveAsync(
           processModule({ srcUrl: realUrl, context }),
           { resolve: cachedResolve, load: parentGetSource }
         )
-        return { source: onWrapSuccess(realUrl, context, originalSpecifier, setters) }
+        return { source: onWrapSuccess(realUrl, context, originalSpecifier, setters, originNamespaces) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         // Revert back to the non-iitm URL
@@ -754,11 +801,11 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
       const originalSpecifier = specifiers.get(realUrl)
 
       try {
-        const { setters } = driveSync(
+        const { setters, originNamespaces } = driveSync(
           processModule({ srcUrl: realUrl, context }),
           { resolve: cachedResolve, load: nextLoad }
         )
-        return { source: onWrapSuccess(realUrl, context, originalSpecifier, setters) }
+        return { source: onWrapSuccess(realUrl, context, originalSpecifier, setters, originNamespaces) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         url = realUrl

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -241,36 +241,56 @@ ${reExportLine}`
  * before descending into its subtree and removed once that subtree finishes, so
  * it tracks the active path rather than every URL ever visited.
  *
- * @returns {Generator<Array, Map<string, string>>} A generator that yields I/O
- * operations and ultimately returns the shimmed setters for all the exports
- * from the module and any transitive export all modules.
+ * @returns {Generator<Array, { setters: Map<string, string>, origins: (Map<string, string> | undefined) }>}
+ * A generator that yields I/O operations and ultimately returns the shimmed
+ * setters for all the exports from the module and any transitive export all
+ * modules, plus the module each `*`-sourced name was defined in. `origins` lets
+ * a caller tell a genuinely ambiguous `export *` collision (same name from two
+ * different modules) apart from the same binding reached through more than one
+ * re-export path; it is `undefined` for a module with no `export *`.
  */
 function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen }) {
   const exportNames = yield * getExports(srcUrl, context)
-  const starExports = new Set()
   const setters = new Map()
 
-  const addSetter = (name, setter, isStarExport = false) => {
+  // The dedup bookkeeping only matters once a `*` re-export collides with a name
+  // already present, so it stays unallocated for the common module whose names
+  // are all distinct. `starExports` records which live names came from a `*`
+  // re-export (so an explicit export can override them); `starOrigins` records
+  // the defining module of each `*`-sourced name, so two `*` re-exports of the
+  // same name can be told apart.
+  let starExports
+  let starOrigins
+
+  const addSetter = (name, setter, isStarExport, origin) => {
     if (setters.has(name)) {
       if (isStarExport) {
-        // If there's already a matching star export, delete it
+        // A `*` re-export collides with an existing `*` re-export. Per
+        // ECMAScript ResolveExport this is ambiguous and excluded only when the
+        // two name the same export from *different* modules; the same binding
+        // reached through two re-export chains resolves to one module and stays
+        // exported (tc39/ecma262#3715). Keep it only when the origins match.
         if (starExports.has(name)) {
-          setters.delete(name)
+          if (starOrigins.get(name) !== origin) {
+            setters.delete(name)
+            starExports.delete(name)
+            starOrigins.delete(name)
+          }
         }
-        // and return so this is excluded
+        // An explicit export already shadows the `*` re-export; leave it.
         return
       }
 
-      // if we already have this export but it is from a * export, overwrite it
-      if (starExports.has(name)) {
+      // An explicit named export overrides a `*` re-export of the same name.
+      if (starExports !== undefined && starExports.has(name)) {
         starExports.delete(name)
+        starOrigins.delete(name)
         setters.set(name, setter)
       }
     } else {
-      // Store export * exports so we know they can be overridden by explicit
-      // named exports
       if (isStarExport) {
         starExports.add(name)
+        starOrigins.set(name, origin)
       }
 
       setters.set(name, setter)
@@ -299,6 +319,11 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
       // parent's `format` to know if this sub-module is ESM or CJS!
       const result = yield [RESOLVE, newSpecifier, { parentURL: srcUrl }]
 
+      // First `*` re-export: allocate the dedup bookkeeping lazily so a module
+      // without one pays nothing.
+      starExports ??= new Set()
+      starOrigins ??= new Map()
+
       // `export *` graphs are normally only a handful of levels deep. A cycle
       // (`a` re-exports `b`, `b` re-exports `a`) instead recurses without bound
       // and exhausts memory. Rather than track every URL on the common shallow
@@ -316,7 +341,7 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
       }
 
       try {
-        const subSetters = yield * processModule({
+        const sub = yield * processModule({
           srcUrl: result.url,
           context: { ...context, format: result.format },
           excludeDefault: true,
@@ -324,18 +349,18 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
           seen
         })
 
-        for (const [name, setter] of subSetters.entries()) {
-          addSetter(name, setter, true)
+        for (const [name, setter] of sub.setters.entries()) {
+          addSetter(name, setter, true, sub.origins?.get(name) ?? result.url)
         }
       } finally {
         seen?.delete(result.url)
       }
     } else {
-      addSetter(n, buildSetter(n, srcUrl))
+      addSetter(n, buildSetter(n, srcUrl), false)
     }
   }
 
-  return setters
+  return { setters, origins: starOrigins }
 }
 
 function addIitm (url) {
@@ -705,7 +730,7 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
       const originalSpecifier = specifiers.get(realUrl)
 
       try {
-        const setters = await driveAsync(
+        const { setters } = await driveAsync(
           processModule({ srcUrl: realUrl, context }),
           { resolve: cachedResolve, load: parentGetSource }
         )
@@ -729,7 +754,7 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
       const originalSpecifier = specifiers.get(realUrl)
 
       try {
-        const setters = driveSync(
+        const { setters } = driveSync(
           processModule({ srcUrl: realUrl, context }),
           { resolve: cachedResolve, load: nextLoad }
         )

--- a/test/fixtures/reexport-explicit-override.mjs
+++ b/test/fixtures/reexport-explicit-override.mjs
@@ -1,0 +1,2 @@
+export * from './duplicate-a.mjs'
+export { foo } from './duplicate-c.mjs'

--- a/test/fixtures/reexport-nested-agg.mjs
+++ b/test/fixtures/reexport-nested-agg.mjs
@@ -1,0 +1,5 @@
+// `nested` reaches here through two `export *` chains that both bottom out at
+// reexport-nested-leaf.mjs, so the surviving same-origin collision is detected
+// while processing this module.
+export * from './reexport-nested-leaf.mjs'
+export * from './reexport-nested-mid.mjs'

--- a/test/fixtures/reexport-nested-leaf.mjs
+++ b/test/fixtures/reexport-nested-leaf.mjs
@@ -1,0 +1,1 @@
+export const nested = 42

--- a/test/fixtures/reexport-nested-mid.mjs
+++ b/test/fixtures/reexport-nested-mid.mjs
@@ -1,0 +1,1 @@
+export * from './reexport-nested-leaf.mjs'

--- a/test/fixtures/reexport-nested-top.mjs
+++ b/test/fixtures/reexport-nested-top.mjs
@@ -1,0 +1,4 @@
+// A `*` re-export of a module that itself resolved a same-origin collision, so
+// the alias minted while processing reexport-nested-agg.mjs must propagate up
+// to this wrapper's imports.
+export * from './reexport-nested-agg.mjs'

--- a/test/fixtures/reexport-same-source-leaf.mjs
+++ b/test/fixtures/reexport-same-source-leaf.mjs
@@ -1,0 +1,1 @@
+export const val = 1

--- a/test/fixtures/reexport-same-source-mid.mjs
+++ b/test/fixtures/reexport-same-source-mid.mjs
@@ -1,0 +1,1 @@
+export * from './reexport-same-source-leaf.mjs'

--- a/test/fixtures/reexport-same-source.mjs
+++ b/test/fixtures/reexport-same-source.mjs
@@ -1,0 +1,2 @@
+export * from './reexport-same-source-leaf.mjs'
+export * from './reexport-same-source-mid.mjs'

--- a/test/hook/reexport-same-source.mjs
+++ b/test/hook/reexport-same-source.mjs
@@ -1,16 +1,38 @@
 import * as lib from '../fixtures/reexport-same-source.mjs'
+import * as nested from '../fixtures/reexport-nested-top.mjs'
 import { strictEqual } from 'assert'
 import Hook from '../../index.js'
 
 // `val` reaches the entry module through two `export *` chains that both bottom
 // out at the same leaf module, so per ECMAScript ResolveExport it is one binding
-// and stays exported (issue #171). The previous dedup treated any name from two
-// `*` re-exports as ambiguous and dropped it. The exported value is wired up by
-// the stacked wrapper-identity fix; this test pins the membership half.
+// that stays exported and keeps its value (issue #171). The previous dedup
+// dropped it as ambiguous; reading the value off the aggregate namespace then
+// returned undefined because Node sees the two chains as distinct wrapper
+// modules. The wrapper reads each re-exported binding from its defining module.
+//
+// `nested` exercises the same collision one level down: the entry module
+// `export *`s a module that itself resolved the collision, so the alias minted
+// there has to propagate up into this wrapper's imports.
 Hook((exports, name) => {
   if (name.includes('reexport-same-source.mjs')) {
     strictEqual('val' in exports, true)
+    strictEqual(exports.val, 1)
+  }
+  if (name.includes('reexport-nested-top.mjs')) {
+    strictEqual('nested' in exports, true)
+    strictEqual(exports.nested, 42)
   }
 })
 
 strictEqual('val' in lib, true)
+strictEqual(lib.val, 1)
+strictEqual('nested' in nested, true)
+strictEqual(nested.nested, 42)
+
+const ambiguous = await import('../fixtures/duplicate.mjs')
+const explicit = await import('../fixtures/duplicate-explicit.mjs')
+const override = await import('../fixtures/reexport-explicit-override.mjs')
+
+strictEqual('foo' in ambiguous, false)
+strictEqual(explicit.foo, 'c')
+strictEqual(override.foo, 'c')

--- a/test/hook/reexport-same-source.mjs
+++ b/test/hook/reexport-same-source.mjs
@@ -1,0 +1,16 @@
+import * as lib from '../fixtures/reexport-same-source.mjs'
+import { strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+// `val` reaches the entry module through two `export *` chains that both bottom
+// out at the same leaf module, so per ECMAScript ResolveExport it is one binding
+// and stays exported (issue #171). The previous dedup treated any name from two
+// `*` re-exports as ambiguous and dropped it. The exported value is wired up by
+// the stacked wrapper-identity fix; this test pins the membership half.
+Hook((exports, name) => {
+  if (name.includes('reexport-same-source.mjs')) {
+    strictEqual('val' in exports, true)
+  }
+})
+
+strictEqual('val' in lib, true)

--- a/test/register/v22.15-sync-reexport-same-source.mjs
+++ b/test/register/v22.15-sync-reexport-same-source.mjs
@@ -1,0 +1,33 @@
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+import Hook from '../../index.js'
+import { strictEqual } from 'node:assert'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+register()
+
+let sawSameSource = false
+let sawNested = false
+
+// eslint-disable-next-line no-new
+new Hook((exports, name) => {
+  if (typeof name === 'string' && name.includes('reexport-same-source.mjs')) {
+    sawSameSource = true
+    strictEqual(exports.val, 1)
+  }
+  if (typeof name === 'string' && name.includes('reexport-nested-top.mjs')) {
+    sawNested = true
+    strictEqual(exports.nested, 42)
+  }
+})
+
+const lib = await import('../fixtures/reexport-same-source.mjs')
+const nested = await import('../fixtures/reexport-nested-top.mjs')
+
+strictEqual(sawSameSource, true)
+strictEqual(lib.val, 1)
+strictEqual(sawNested, true)
+strictEqual(nested.nested, 42)


### PR DESCRIPTION
A name that reaches a module through two export * re-exports which both bottom out at the same defining module is one binding, not an ambiguous collision, so it must stay exported. processModule dropped it because addSetter treated any name arriving from two * re-exports as ambiguous regardless of where it was defined. Per ECMAScript ResolveExport, ambiguity requires the name to resolve to different modules (or different binding names); the same binding reached through more than one chain resolves to one module and stays exported (https://github.com/tc39/ecma262/pull/3715).

This tracks the defining module per name and excludes only when two * re-exports name it from different modules — restoring the export name. The genuinely-ambiguous case (export * from './a' + export * from './b' where both declare their own foo) still drops foo, as the existing duplicate-exports.mjs test asserts.
A binding re-exported into one module through more than one `export *` chain came back `undefined` even once it was no longer dropped as ambiguous. The wrapper read every name off the aggregating module's namespace, and Node treats the two chains as distinct wrapper modules, so the aggregate namespace leaves the name ambiguous and exposes `undefined`. The defining module always holds the value, so the wrapper now imports one namespace per defining module and points each re-exported binding's setter at the module that declares it.

Fixes: https://github.com/nodejs/import-in-the-middle/issues/171