### PR TITLE
perf: shrink generated wrapper source

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -204,43 +204,18 @@ function buildSetter (n, srcUrl) {
   const objectKey = JSON.stringify(n)
   const reExportedName = n === 'default' ? n : objectKey
 
-  // For the module.exports synthetic export (Node 23+), fall back to $default
-  // when namespace['module.exports'] is not exposed by the native ESM namespace
-  // (builtins don't expose it). This ensures the IITM hook proxy returns the
-  // actual CJS value (e.g. EventEmitter) when an instrumentor reads
-  // capturedExports['module.exports'], rather than undefined.
-  const moduleExportsFallback = n === 'module.exports' ? ' ?? $default' : ''
+  // `1` makes __bind fall back to namespace['default'] for the module.exports
+  // synthetic export, which builtins don't expose on the native ESM namespace.
+  const fallback = n === 'module.exports' ? ', 1' : ''
 
+  // Builtins don't expose the module.exports synthetic name, so skip its re-export.
   const reExportLine = (n === 'module.exports' && (srcUrl.startsWith('node:') || builtinModules.includes(srcUrl)))
     ? ''
     : `export { ${variableName} as ${reExportedName} }`
 
-  return `
-      let ${variableName}
-      __overridden[${objectKey}] = false
-      let ${variableName}Defer = false
-      try {
-        ${variableName} = _[${objectKey}] = namespace[${objectKey}]${moduleExportsFallback}
-      } catch (err) {
-        if (!(err instanceof ReferenceError)) throw err
-        ${variableName}Defer = true
-      }
-
-      if (${variableName}Defer || ${variableName} === undefined) {
-        __pending.push(__makeUpdater(
-          ${objectKey},
-          () => namespace[${objectKey}]${moduleExportsFallback},
-          (v) => { ${variableName} = _[${objectKey}] = v }
-        ))
-      }
-      ${reExportLine}
-      set[${objectKey}] = (v) => {
-        __overridden[${objectKey}] = true
-        ${variableName} = v
-        return true
-      }
-      get[${objectKey}] = () => ${variableName}
-      `
+  return `let ${variableName}
+__bind(${objectKey}, v => { ${variableName} = v }, () => ${variableName}${fallback})
+${reExportLine}`
 }
 
 /**
@@ -639,6 +614,31 @@ function __flushPendingOnce () {
     if (fn() !== true) next.push(fn)
   }
   __pending = next
+}
+
+function __bind (key, write, read, useFallback) {
+  const readSource = useFallback
+    ? () => namespace[key] ?? namespace['default']
+    : () => namespace[key]
+  __overridden[key] = false
+  let deferred = false
+  try {
+    const v = readSource()
+    write(v)
+    _[key] = v
+  } catch (err) {
+    if (!(err instanceof ReferenceError)) throw err
+    deferred = true
+  }
+  if (deferred || read() === undefined) {
+    __pending.push(__makeUpdater(key, readSource, (v) => { write(v); _[key] = v }))
+  }
+  set[key] = (v) => {
+    __overridden[key] = true
+    write(v)
+    return true
+  }
+  get[key] = read
 }
 
 ${Array.from(setters.values()).join('\n')}


### PR DESCRIPTION
## Summary

Every wrapped module makes Node compile a generated wrapper, and that compile is the dominant iitm startup cost once the parser is no longer Acorn. Each export inlined ~25 lines of identical read / defer / override / set / get wiring, so a realistic 396-module / 3258-export graph emitted 2.85 MiB of wrapper source for V8 to parse. This moves that wiring into a single `__bind` helper emitted once per wrapper; each export keeps only the live `let` binding and static `export` the module system requires, plus a one-line `__bind` call.

Behavior is unchanged: live bindings, deferred resolution for circular imports, the Hook set/get proxy, and the Node 23+ `module.exports` fallback all keep their existing semantics.

## Numbers

396-module / 3258-export graph, synchronous in-thread loader, Node 24.16, `--cpu-prof --cpu-prof-interval=50`:

- generated wrapper source: 2.85 MiB -> 1.25 MiB (-56%)
- `compileSourceTextModule` self time: 47.1 ms -> 24.8 ms
- total wrap+load: 192.8 ms -> 144.4 ms (-25%)

## Test plan

- [ ] Existing suite green (sync + off-thread): `npm test`
- [ ] Sync in-thread hooks on Node >= 24.11.1 (`test/register/v22.15-sync-register-hooks*.mjs`)
- [ ] Circular-import deferral and the `module.exports` builtin fallback still resolve

Stacked on #259 (es-module-lexer); the compile win is what remains after the parser swap, so review/merge after that.