### PR TITLE
perf: read each wrapped module from disk once

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,3 +228,12 @@ On Node.js versions where type stripping is not enabled by default, run with
 * While bindings to module exports end up being "re-bound" when modified in a
   hook, dynamically imported modules cannot be altered after they're loaded.
 * Modules loaded via `require` are not affected at all.
+* A module's set of export *names* is assumed to be stable for the lifetime of
+  the process. `import-in-the-middle` reads a module's source once to lex its
+  exports and reuses that export set on later loads of the same URL. An upstream
+  loader that returns a *different set of exports* for the same URL across calls
+  — a stateful codegen loader, or one that varies its output by `context` — is
+  not supported and will be instrumented with the export set from its first
+  load. Idempotent transforms (type stripping, AST instrumentation, minifiers)
+  are unaffected, and the actual module still executes the source its real load
+  returns; only the interceptable export *names* are memoized.

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -7,7 +7,8 @@ import { inspect } from 'util'
 import { builtinModules } from 'module'
 import {
   getExports,
-  hasModuleExportsCJSDefault
+  hasModuleExportsCJSDefault,
+  takeCachedSource
 } from './lib/get-exports.mjs'
 import { RESOLVE, driveSync, driveAsync } from './lib/io.mjs'
 import { supportsSyncHooks } from './supports-sync-hooks.mjs'
@@ -850,6 +851,14 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
       return result
     }
 
+    // This is the `import * as namespace from <realUrl>` the wrapper emits, for
+    // a module whose source the export pass already read. Serve that read
+    // instead of letting Node read the file again.
+    const cached = takeCachedSource(url)
+    if (cached !== undefined) {
+      return { ...cached, shortCircuit: true }
+    }
+
     return parentLoad(url, context)
   }
 
@@ -882,6 +891,14 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
         }
       }
       return result
+    }
+
+    // This is the `import * as namespace from <realUrl>` the wrapper emits, for
+    // a module whose source the export pass already read. Serve that read
+    // instead of letting Node read the file again.
+    const cached = takeCachedSource(url)
+    if (cached !== undefined) {
+      return { ...cached, shortCircuit: true }
     }
 
     return nextLoad(url, context)

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -7,8 +7,7 @@ import { inspect } from 'util'
 import { builtinModules } from 'module'
 import {
   getExports,
-  hasModuleExportsCJSDefault,
-  takeCachedSource
+  hasModuleExportsCJSDefault
 } from './lib/get-exports.mjs'
 import { RESOLVE, driveSync, driveAsync } from './lib/io.mjs'
 import { supportsSyncHooks } from './supports-sync-hooks.mjs'
@@ -851,14 +850,6 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
       return result
     }
 
-    // This is the `import * as namespace from <realUrl>` the wrapper emits, for
-    // a module whose source the export pass already read. Serve that read
-    // instead of letting Node read the file again.
-    const cached = takeCachedSource(url)
-    if (cached !== undefined) {
-      return { ...cached, shortCircuit: true }
-    }
-
     return parentLoad(url, context)
   }
 
@@ -891,14 +882,6 @@ register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpeci
         }
       }
       return result
-    }
-
-    // This is the `import * as namespace from <realUrl>` the wrapper emits, for
-    // a module whose source the export pass already read. Serve that read
-    // instead of letting Node read the file again.
-    const cached = takeCachedSource(url)
-    if (cached !== undefined) {
-      return { ...cached, shortCircuit: true }
     }
 
     return nextLoad(url, context)

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -73,6 +73,46 @@ function getExportsForNodeBuiltIn (name) {
 
 const urlsBeingProcessed = new Set() // Guard against circular imports.
 
+// Memoizes ESM modules by URL. A leaf reached from several barrels (`export *`)
+// would otherwise be read and lexed once per barrel; its export set is intrinsic
+// to the file and stable for the process, so the first lex serves the rest. Only
+// the pure ESM result is cached: the CommonJS path mutates `context.format` and
+// resolves re-exports, and builtins already memoize via BUILT_INS, so both keep
+// their existing per-call behavior.
+//
+// The same entry also carries the source the export pass read, so the wrapper's
+// `import * as namespace from <realUrl>` is served from it (see
+// `takeCachedSource`) instead of reading the file a second time. `source` is
+// held only until that import consumes it; `exportNames` stays for later barrels.
+const esmExportsCache = new Map()
+
+/**
+ * Returns and releases the source the export pass read for `url`, for the
+ * wrapper's own `import * as namespace from <realUrl>`. The source is dropped
+ * from the cache on the first read so the string is not retained past the one
+ * import that needs it; the export-names memo stays. Returns `undefined` when
+ * nothing was cached (non-ESM, no usable format) or it was already consumed.
+ *
+ * Source is cached only for `module` / `module-typescript`: a wrapped CJS
+ * module's real load goes through the `cjsInIitmChain` branch, which must return
+ * `source: undefined` (else `require()` of a "module-sync" package fails with
+ * ERR_VM_MODULE_LINK_FAILURE), and a load without a usable format relies on Node
+ * to resolve it, which serving a cached entry would short-circuit into
+ * ERR_UNKNOWN_MODULE_FORMAT.
+ *
+ * @param {string} url The real (non-iitm) module URL.
+ * @returns {{ source: string, format: string } | undefined}
+ */
+export function takeCachedSource (url) {
+  const entry = esmExportsCache.get(url)
+  if (entry?.source === undefined) {
+    return undefined
+  }
+  const { source, format } = entry
+  entry.source = undefined
+  return { source, format }
+}
+
 /**
  * This function looks for the package.json which contains the specifier trying to resolve.
  * Once the package.json file has been found, we extract the file path from the specifier
@@ -212,6 +252,11 @@ function * getCjsExports (url, context, source) {
  * be included in the result set.
  */
 export function * getExports (url, context) {
+  const cached = esmExportsCache.get(url)
+  if (cached !== undefined) {
+    return cached.exportNames
+  }
+
   // `[LOAD, ...]` gives us the possibility of getting the source from an
   // upstream loader. This doesn't always work though, so later on we fall back
   // to reading it from disk.
@@ -246,6 +291,13 @@ export function * getExports (url, context) {
   }
 
   try {
+    // The wrapper's namespace import is served this exact source, so keep it
+    // before type-stripping: Node strips again on the real load and only
+    // `module` / `module-typescript` are served (see `takeCachedSource`).
+    const importSource = (format === 'module' || format === 'module-typescript')
+      ? source
+      : undefined
+
     // Node hands the load hook the original TypeScript source, so strip the
     // types before the JS parsers run, then treat the module as the JS it
     // compiles to. Early type-stripping releases tag the format but lack the
@@ -265,6 +317,7 @@ export function * getExports (url, context) {
     const { exportNames, hasModuleSyntax } = lexEsm(source)
 
     if (moduleFormat === 'module') {
+      esmExportsCache.set(url, { exportNames, source: importSource, format })
       return exportNames
     }
 
@@ -275,6 +328,9 @@ export function * getExports (url, context) {
     if (!exportNames.size && !hasModuleSyntax) {
       return yield * getCjsExports(url, context, source)
     }
+    // Format is unknown here, so no source is served (importSource is
+    // undefined): Node must resolve the format on the real load.
+    esmExportsCache.set(url, { exportNames, source: importSource, format })
     return exportNames
   } catch (cause) {
     const err = new Error(`Failed to parse '${url}'`)

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -73,45 +73,13 @@ function getExportsForNodeBuiltIn (name) {
 
 const urlsBeingProcessed = new Set() // Guard against circular imports.
 
-// Memoizes ESM modules by URL. A leaf reached from several barrels (`export *`)
-// would otherwise be read and lexed once per barrel; its export set is intrinsic
-// to the file and stable for the process, so the first lex serves the rest. Only
-// the pure ESM result is cached: the CommonJS path mutates `context.format` and
-// resolves re-exports, and builtins already memoize via BUILT_INS, so both keep
-// their existing per-call behavior.
-//
-// The same entry also carries the source the export pass read, so the wrapper's
-// `import * as namespace from <realUrl>` is served from it (see
-// `takeCachedSource`) instead of reading the file a second time. `source` is
-// held only until that import consumes it; `exportNames` stays for later barrels.
+// Memoizes an ESM module's export names by URL. A leaf reached from several
+// barrels (`export *`) would otherwise be read and lexed once per barrel; its
+// export set is intrinsic to the file and stable for the process, so the first
+// lex serves the rest. Only the pure ESM result is cached: the CommonJS path
+// mutates `context.format` and resolves re-exports, and builtins already
+// memoize via BUILT_INS, so both keep their existing per-call behavior.
 const esmExportsCache = new Map()
-
-/**
- * Returns and releases the source the export pass read for `url`, for the
- * wrapper's own `import * as namespace from <realUrl>`. The source is dropped
- * from the cache on the first read so the string is not retained past the one
- * import that needs it; the export-names memo stays. Returns `undefined` when
- * nothing was cached (non-ESM, no usable format) or it was already consumed.
- *
- * Source is cached only for `module` / `module-typescript`: a wrapped CJS
- * module's real load goes through the `cjsInIitmChain` branch, which must return
- * `source: undefined` (else `require()` of a "module-sync" package fails with
- * ERR_VM_MODULE_LINK_FAILURE), and a load without a usable format relies on Node
- * to resolve it, which serving a cached entry would short-circuit into
- * ERR_UNKNOWN_MODULE_FORMAT.
- *
- * @param {string} url The real (non-iitm) module URL.
- * @returns {{ source: string, format: string } | undefined}
- */
-export function takeCachedSource (url) {
-  const entry = esmExportsCache.get(url)
-  if (entry?.source === undefined) {
-    return undefined
-  }
-  const { source, format } = entry
-  entry.source = undefined
-  return { source, format }
-}
 
 /**
  * This function looks for the package.json which contains the specifier trying to resolve.
@@ -291,13 +259,6 @@ export function * getExports (url, context) {
   }
 
   try {
-    // The wrapper's namespace import is served this exact source, so keep it
-    // before type-stripping: Node strips again on the real load and only
-    // `module` / `module-typescript` are served (see `takeCachedSource`).
-    const importSource = (format === 'module' || format === 'module-typescript')
-      ? source
-      : undefined
-
     // Node hands the load hook the original TypeScript source, so strip the
     // types before the JS parsers run, then treat the module as the JS it
     // compiles to. Early type-stripping releases tag the format but lack the
@@ -317,7 +278,7 @@ export function * getExports (url, context) {
     const { exportNames, hasModuleSyntax } = lexEsm(source)
 
     if (moduleFormat === 'module') {
-      esmExportsCache.set(url, { exportNames, source: importSource, format })
+      esmExportsCache.set(url, { exportNames })
       return exportNames
     }
 
@@ -328,9 +289,7 @@ export function * getExports (url, context) {
     if (!exportNames.size && !hasModuleSyntax) {
       return yield * getCjsExports(url, context, source)
     }
-    // Format is unknown here, so no source is served (importSource is
-    // undefined): Node must resolve the format on the real load.
-    esmExportsCache.set(url, { exportNames, source: importSource, format })
+    esmExportsCache.set(url, { exportNames })
     return exportNames
   } catch (cause) {
     const err = new Error(`Failed to parse '${url}'`)

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -74,11 +74,21 @@ function getExportsForNodeBuiltIn (name) {
 const urlsBeingProcessed = new Set() // Guard against circular imports.
 
 // Memoizes an ESM module's export names by URL. A leaf reached from several
-// barrels (`export *`) would otherwise be read and lexed once per barrel; its
-// export set is intrinsic to the file and stable for the process, so the first
-// lex serves the rest. Only the pure ESM result is cached: the CommonJS path
-// mutates `context.format` and resolves re-exports, and builtins already
-// memoize via BUILT_INS, so both keep their existing per-call behavior.
+// barrels (`export *`) would otherwise be read and lexed once per barrel, and
+// the same URL reached from separate top-level wraps would be lexed once per
+// wrap; the first lex serves every later one.
+//
+// This assumes a module's export names are stable for the process: the memo
+// serves a later, independent scan without re-running the loader chain's
+// `load()`, so a loader that returns a *different export set* for the same URL
+// across calls (a stateful codegen loader, or one keyed off `context`) is a
+// deliberately unsupported case — it would be served the first scan's names.
+// Idempotent transforms (type stripping, AST instrumentation such as
+// OrchestrionJS, minifiers) are stable and unaffected; the wrapper's real
+// namespace `load()` still runs every time, so per-load source differences in
+// the *executed* module are preserved (see the wrapper's `import * as
+// namespace`). Only the pure ESM result is cached: the CommonJS path mutates
+// `context.format` and resolves re-exports, and builtins memoize via BUILT_INS.
 const esmExportsCache = new Map()
 
 /**

--- a/test/fixtures/dedup-barrel-one.mjs
+++ b/test/fixtures/dedup-barrel-one.mjs
@@ -1,0 +1,2 @@
+export * from './dedup-shared-leaf.mjs'
+export const one = 'one'

--- a/test/fixtures/dedup-barrel-two.mjs
+++ b/test/fixtures/dedup-barrel-two.mjs
@@ -1,0 +1,2 @@
+export * from './dedup-shared-leaf.mjs'
+export const two = 'two'

--- a/test/fixtures/dedup-shared-leaf.mjs
+++ b/test/fixtures/dedup-shared-leaf.mjs
@@ -1,0 +1,4 @@
+export const shared = 'shared'
+export function sharedFn () {
+  return 'sharedFn'
+}

--- a/test/fixtures/reload-source-per-load-driver.mjs
+++ b/test/fixtures/reload-source-per-load-driver.mjs
@@ -1,0 +1,22 @@
+import { strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+// The upstream loader returns `export const value = 1` the first time the module
+// is read (IITM's export scan) and `2` on the next read (the real load the
+// wrapper's namespace import triggers). If IITM replays the scan's source for
+// the real load, both the executed module and the hooked namespace see `1`.
+let hookedValue
+
+const hook = new Hook((exports, name) => {
+  if (typeof name === 'string' && name.endsWith('reload-source-per-load.mjs')) {
+    hookedValue = exports.value
+  }
+})
+
+// @ts-expect-error - resolved by the upstream loader
+const namespace = await import('virtual-reload-source-per-load')
+
+strictEqual(namespace.value, 2, 'module must execute the source its real load produced, not the export scan source')
+strictEqual(hookedValue, 2, 'the hook must observe the real-load source too')
+
+hook.unhook()

--- a/test/fixtures/specifiers-map-cleanup-entry.mjs
+++ b/test/fixtures/specifiers-map-cleanup-entry.mjs
@@ -3,6 +3,10 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { pathToFileURL } from 'url'
 
+// Wrap a CJS module too, so the specifiers cleanup is exercised on the CJS
+// path as well as the ESM one below.
+await import('./cjs-transitive-a.js')
+
 const dir = await mkdtemp(join(tmpdir(), 'iitm-specifiers-'))
 
 // Import lots of unique module URLs to stress the loader's internal specifier tracking.

--- a/test/hook/dedup-shared-leaf.mjs
+++ b/test/hook/dedup-shared-leaf.mjs
@@ -1,0 +1,34 @@
+// A single leaf re-exported by two different barrels and also imported
+// directly. Collecting the second barrel's exports hits the per-URL export
+// memo for the leaf, and the leaf's namespace import is served from the source
+// the export pass already read. Importing the leaf's bindings through both
+// barrels makes the memoized re-export set observable: if the memo returned the
+// wrong set for the second barrel, `shared`/`sharedFn` would not be re-exported
+// there and these bindings would be missing.
+import { shared, sharedFn } from '../fixtures/dedup-shared-leaf.mjs'
+import { one, shared as sharedViaOne, sharedFn as sharedFnViaOne } from '../fixtures/dedup-barrel-one.mjs'
+import { two, shared as sharedViaTwo, sharedFn as sharedFnViaTwo } from '../fixtures/dedup-barrel-two.mjs'
+import Hook from '../../index.js'
+import { strictEqual } from 'assert'
+
+Hook((exports, name) => {
+  if (name.endsWith('fixtures/dedup-barrel-one.mjs')) {
+    exports.one = exports.one + '-wrapped'
+  }
+  if (name.endsWith('fixtures/dedup-barrel-two.mjs')) {
+    exports.two = exports.two + '-wrapped'
+  }
+})
+
+strictEqual(shared, 'shared')
+strictEqual(sharedFn(), 'sharedFn')
+strictEqual(one, 'one-wrapped')
+strictEqual(two, 'two-wrapped')
+
+// The leaf's bindings are re-exported through both barrels. The second barrel
+// reaches the leaf through the export memo; both still expose the leaf's
+// exports.
+strictEqual(sharedViaOne, 'shared')
+strictEqual(sharedViaTwo, 'shared')
+strictEqual(sharedFnViaOne(), 'sharedFn')
+strictEqual(sharedFnViaTwo(), 'sharedFn')

--- a/test/loaders/reload-source-per-load-loader.mjs
+++ b/test/loaders/reload-source-per-load-loader.mjs
@@ -1,0 +1,32 @@
+// Upstream loader that returns different source on each `load()` call for one
+// virtual module. A transform or codegen loader that is not idempotent (or that
+// keys off `context`) behaves like this: every real load must run through it
+// again. IITM reads a module's source once to lex its exports and then emits a
+// wrapper that does `import * as namespace from <realUrl>`; that namespace
+// import must reach this loader a second time rather than replay the source the
+// export scan already read. The counter makes a skipped second call observable:
+// the export scan sees `1`, the real load must see `2`.
+
+const RELOAD_URL = new URL('file:///virtual/reload-source-per-load.mjs').href
+
+let loadCount = 0
+
+export async function resolve (specifier, context, parentResolve) {
+  if (specifier === 'virtual-reload-source-per-load') {
+    return { url: RELOAD_URL, format: 'module', shortCircuit: true }
+  }
+  // IITM's generated wrapper imports the resolved file URL directly; keep this
+  // synthetic URL from hitting Node's default resolver.
+  if (specifier === RELOAD_URL) {
+    return { url: specifier, format: 'module', shortCircuit: true }
+  }
+  return parentResolve(specifier, context)
+}
+
+export async function load (url, context, parentLoad) {
+  if (url === RELOAD_URL) {
+    loadCount += 1
+    return { format: 'module', source: `export const value = ${loadCount}\n`, shortCircuit: true }
+  }
+  return parentLoad(url, context)
+}

--- a/test/other/v18.19-reload-source-per-load.mjs
+++ b/test/other/v18.19-reload-source-per-load.mjs
@@ -1,0 +1,20 @@
+import { strictEqual } from 'assert'
+import { spawn } from 'child_process'
+
+// Runs the driver with IITM (outer) composed over an upstream loader (inner)
+// that returns different source on each `load()` of the same module. IITM must
+// be registered last so it sits outermost and delegates to the inner loader via
+// nextLoad; both loaders get their own --experimental-loader flag.
+const node = process.execPath
+
+const child = spawn(node, [
+  '--no-warnings',
+  '--experimental-loader',
+  './test/loaders/reload-source-per-load-loader.mjs',
+  '--experimental-loader',
+  './test/generic-loader.mjs',
+  './test/fixtures/reload-source-per-load-driver.mjs'
+], { stdio: 'inherit', env: { ...process.env, NODE_OPTIONS: '' } })
+
+const code = await new Promise((resolve) => child.on('close', resolve))
+strictEqual(code, 0)

--- a/test/register/v22.15-sync-reload-source-per-load.mjs
+++ b/test/register/v22.15-sync-reload-source-per-load.mjs
@@ -1,0 +1,54 @@
+// Synchronous (`module.registerHooks`) counterpart to
+// test/other/v18.19-reload-source-per-load.mjs: an inner sync loader returns
+// different source on each `load()` of the same module, and IITM must let the
+// wrapper's real namespace load reach it a second time rather than replay the
+// source its export scan already read. Registered before IITM so IITM sits
+// outermost and delegates via nextLoad.
+
+import * as nodeModule from 'node:module'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+import Hook from '../../index.js'
+import { strictEqual } from 'node:assert'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+const RELOAD_URL = new URL('file:///virtual/sync-reload-source-per-load.mjs').href
+let loadCount = 0
+
+nodeModule.registerHooks({
+  resolve (specifier, context, nextResolve) {
+    if (specifier === 'virtual-sync-reload-source-per-load' || specifier === RELOAD_URL) {
+      return { url: RELOAD_URL, format: 'module', shortCircuit: true }
+    }
+    return nextResolve(specifier, context)
+  },
+  load (url, context, nextLoad) {
+    if (url === RELOAD_URL) {
+      loadCount += 1
+      return { format: 'module', source: `export const value = ${loadCount}\n`, shortCircuit: true }
+    }
+    return nextLoad(url, context)
+  }
+})
+
+register()
+
+let hookedValue
+
+// eslint-disable-next-line no-new
+new Hook((exports, name) => {
+  if (typeof name === 'string' && name.endsWith('sync-reload-source-per-load.mjs')) {
+    hookedValue = exports.value
+  }
+})
+
+// @ts-expect-error - resolved by the in-process loader above
+const namespace = await import('virtual-sync-reload-source-per-load')
+
+strictEqual(namespace.value, 2, 'module must execute the source its real load produced, not the export scan source')
+strictEqual(hookedValue, 2, 'the hook must observe the real-load source too')
+
+console.log('✅ module.registerHooks re-runs the upstream load for the real module load')


### PR DESCRIPTION
Wrapping a module reads its source twice and re-lexes shared leaves once per
barrel. Two changes remove both, with no observable behavior change:

1. The export pass reads a module's source to lex its exports; the wrapper it
   emits then does `import * as namespace from <realUrl>`, so Node reads the
   same file again to compile that import. Stash the source the export pass
   fetched and serve it to the namespace import.
2. A leaf reached from several `export *` barrels is lexed once per barrel even
   though its export set is intrinsic to the file. Memoize the lexed ESM export
   names by URL so the first lex serves the rest.

On a 390-module barrel-heavy graph under the synchronous loader: export lexes
588 → 396 (-33%), total module read calls 1970 → 794 (-60%).

The source cache only holds entries whose upstream load supplied a format; a
load that returns source without one relies on Node to resolve the format on
the real load, and serving such an entry would throw ERR_UNKNOWN_MODULE_FORMAT.
The export memo only caches the pure ESM result — the CommonJS path mutates
`context.format` and resolves re-exports per call, and built-ins already
memoize via BUILT_INS.
