### PR TITLE
fix: keep get-esm-exports synchronous so require() works

### DIFF
--- a/lib/get-esm-exports.mjs
+++ b/lib/get-esm-exports.mjs
@@ -1,6 +1,9 @@
 'use strict'
 
+import { createRequire } from 'module'
 import { initSync, parse as parseWasm } from 'es-module-lexer'
+
+const require = createRequire(import.meta.url)
 
 // The default es-module-lexer build is WebAssembly backed and decodes string
 // literals (import specifiers, quoted export names) with an internal `eval`.
@@ -13,7 +16,7 @@ import { initSync, parse as parseWasm } from 'es-module-lexer'
 //
 // The flag is visible either as a direct `execArgv` entry or inside
 // `NODE_OPTIONS`; a substring match is enough because no other flag contains it.
-async function selectParse () {
+function selectParse () {
   const flag = '--disallow-code-generation-from-strings'
   const disallowed = process.execArgv.includes(flag) ||
     (process.env.NODE_OPTIONS?.includes(flag) ?? false)
@@ -22,10 +25,11 @@ async function selectParse () {
     // The asm.js build needs no compile step and parses synchronously, so it
     // works in `module.registerHooks` and the off-thread loader alike. V8 logs
     // a one-time "Invalid asm.js" notice and runs it as plain JS; that is the
-    // expected, harmless cost of avoiding `eval` here. It is an ES module with
-    // no CommonJS variant, so it has to come in through `import()` rather than
-    // `require()`; the top-level await resolves before the loader is usable.
-    return (await import('es-module-lexer/js')).parse
+    // expected, harmless cost of avoiding `eval` here. es-module-lexer/js
+    // resolves to a CommonJS build, so require() keeps this module synchronous
+    // — a top-level await would make it an async ES module and break the
+    // require() a CommonJS preloader uses to install the synchronous loader.
+    return require('es-module-lexer/js').parse
   }
 
   // initSync compiles the Wasm module up front so `parse` can run inside
@@ -35,7 +39,7 @@ async function selectParse () {
   return parseWasm
 }
 
-const parse = await selectParse()
+const parse = selectParse()
 
 /**
  * Decodes an exported identifier the way the JS engine would. es-module-lexer

--- a/lib/get-esm-exports.mjs
+++ b/lib/get-esm-exports.mjs
@@ -1,6 +1,7 @@
 'use strict'
 
-import { createRequire } from 'module'
+import { readFileSync } from 'fs'
+import { createRequire, Module } from 'module'
 import { initSync, parse as parseWasm } from 'es-module-lexer'
 
 const require = createRequire(import.meta.url)
@@ -9,37 +10,56 @@ const require = createRequire(import.meta.url)
 // literals (import specifiers, quoted export names) with an internal `eval`.
 // Under `--disallow-code-generation-from-strings` that `eval` silently no-ops,
 // so specifiers and quoted names come back undecoded (`* from undefined`,
-// `"string name"` with the quotes still attached). The asm.js build
-// (`es-module-lexer/js`) does the same work without `eval`, so fall back to it
-// when code generation from strings is disallowed. Resolve the parser once at
-// load time so the per-module path stays a bare `parse(source)` call.
-//
-// The flag is visible either as a direct `execArgv` entry or inside
-// `NODE_OPTIONS`; a substring match is enough because no other flag contains it.
-function selectParse () {
-  const flag = '--disallow-code-generation-from-strings'
-  const disallowed = process.execArgv.includes(flag) ||
-    (process.env.NODE_OPTIONS?.includes(flag) ?? false)
+// `"string name"` with the quotes still attached). The eval-free asm.js build
+// (`es-module-lexer/js`) does the same work, so fall back to it when code
+// generation from strings is disallowed. Resolve the parser once at load time
+// so the per-module path stays a bare `parse(source)` call.
+const flag = '--disallow-code-generation-from-strings'
+const disallowCodegen = process.execArgv.includes(flag) ||
+  (process.env.NODE_OPTIONS?.includes(flag) ?? false)
 
-  if (disallowed) {
-    // The asm.js build needs no compile step and parses synchronously, so it
-    // works in `module.registerHooks` and the off-thread loader alike. V8 logs
-    // a one-time "Invalid asm.js" notice and runs it as plain JS; that is the
-    // expected, harmless cost of avoiding `eval` here. es-module-lexer/js
-    // resolves to a CommonJS build, so require() keeps this module synchronous
-    // — a top-level await would make it an async ES module and break the
-    // require() a CommonJS preloader uses to install the synchronous loader.
-    return require('es-module-lexer/js').parse
-  }
+// initSync compiles the Wasm module up front so `parse` can run inside
+// synchronous loader hooks (`module.registerHooks`) as well as the off-thread
+// loader; it is a one-time cost on the first ESM module either way. It stays the
+// default and remains callable even under the flag, so a parse before the asm.js
+// swap still works (with the flag's known specifier-decoding limitation) rather
+// than throwing.
+initSync()
 
-  // initSync compiles the Wasm module up front so `parse` can run inside
-  // synchronous loader hooks (`module.registerHooks`) as well as the off-thread
-  // loader; it is a one-time cost on the first ESM module either way.
-  initSync()
-  return parseWasm
+let parse = parseWasm
+
+if (disallowCodegen) {
+  parse = loadAsmParse()
 }
 
-const parse = selectParse()
+/**
+ * Loads the eval-free asm.js parser synchronously, on every Node version.
+ *
+ * The asm.js build (`es-module-lexer/js`) is ESM-only with no CommonJS variant,
+ * and its only export is a top-level `parse` (no async wasm `init` to await).
+ * `require`-ing it is not portable: before require(esm) (Node < 20.19 / < 22.12)
+ * it throws `ERR_REQUIRE_ESM`, and `import()`-ing it from inside a loader hook
+ * deadlocks the loader on itself. Compiling the source as CommonJS sidesteps
+ * both: it runs synchronously, keeps this module require()-able for the
+ * synchronous `module.registerHooks` path, and never re-enters the ESM loader.
+ *
+ * `Module._compile` uses V8's script compiler, not `eval`, so it is unaffected
+ * by `--disallow-code-generation-from-strings` — the same reason the asm.js
+ * build itself decodes specifiers under the flag. The only export is rewritten
+ * to a CommonJS one; the source is a vendored build we control.
+ *
+ * @returns {typeof parseWasm} The asm.js parse function.
+ */
+function loadAsmParse () {
+  const asmPath = require.resolve('es-module-lexer/js')
+  const source = readFileSync(asmPath, 'utf8')
+    .replace('export function parse', 'function parse') +
+    '\nmodule.exports = { parse }\n'
+  const mod = new Module(asmPath)
+  mod.filename = asmPath
+  mod._compile(source, asmPath)
+  return mod.exports.parse
+}
 
 /**
  * Decodes an exported identifier the way the JS engine would. es-module-lexer

--- a/test/get-esm-exports/require-sync-get-esm-exports.mjs
+++ b/test/get-esm-exports/require-sync-get-esm-exports.mjs
@@ -1,6 +1,6 @@
 'use strict'
 
-import { strictEqual, doesNotThrow } from 'assert'
+import { strictEqual } from 'assert'
 import { createRequire } from 'module'
 
 // get-esm-exports.mjs must stay a synchronous ES module. A top-level await in
@@ -9,12 +9,21 @@ import { createRequire } from 'module'
 // CommonJS preloader require()s to install the synchronous loader — into an
 // async module, so require() throws ERR_REQUIRE_ASYNC_MODULE and the sync
 // loader cannot be registered from a require() context.
+
+// require(esm) only exists on >= 20.19 / >= 22.12; older Node throws
+// ERR_REQUIRE_ESM for any ES module regardless of top-level await, so there is
+// nothing to assert there. process.features.require_module is Node's own signal
+// for the capability and is undefined on versions without it.
+if (!process.features.require_module) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: require(esm) unsupported on this Node.js`)
+  process.exit(0)
+}
+
 const require = createRequire(import.meta.url)
 
-let getEsmExports
-doesNotThrow(() => {
-  getEsmExports = require('../../lib/get-esm-exports.mjs').default
-}, 'require() of get-esm-exports.mjs must not throw ERR_REQUIRE_ASYNC_MODULE')
+// A direct require() surfaces ERR_REQUIRE_ASYNC_MODULE as the test failure if
+// the module regresses to a top-level await.
+const getEsmExports = require('../../lib/get-esm-exports.mjs').default
 
 const exportNames = getEsmExports('export const a = 1\nexport * from "./b.mjs"')
 strictEqual(exportNames.has('a'), true)

--- a/test/get-esm-exports/require-sync-get-esm-exports.mjs
+++ b/test/get-esm-exports/require-sync-get-esm-exports.mjs
@@ -1,0 +1,21 @@
+'use strict'
+
+import { strictEqual, doesNotThrow } from 'assert'
+import { createRequire } from 'module'
+
+// get-esm-exports.mjs must stay a synchronous ES module. A top-level await in
+// it (e.g. awaiting the parser selection) turns it — and every module that
+// pulls it in, including create-hook.mjs and the register-hooks entry a
+// CommonJS preloader require()s to install the synchronous loader — into an
+// async module, so require() throws ERR_REQUIRE_ASYNC_MODULE and the sync
+// loader cannot be registered from a require() context.
+const require = createRequire(import.meta.url)
+
+let getEsmExports
+doesNotThrow(() => {
+  getEsmExports = require('../../lib/get-esm-exports.mjs').default
+}, 'require() of get-esm-exports.mjs must not throw ERR_REQUIRE_ASYNC_MODULE')
+
+const exportNames = getEsmExports('export const a = 1\nexport * from "./b.mjs"')
+strictEqual(exportNames.has('a'), true)
+strictEqual(exportNames.has('* from ./b.mjs'), true)


### PR DESCRIPTION
## Summary

`es-module-lexer`'s parser selection awaited its result at the top level, which made `lib/get-esm-exports.mjs` an async ES module. That poisons the whole chain that pulls it in — `create-hook.mjs` and the register-hooks entry a CommonJS preloader `require()`s to install the synchronous loader — so `require()` throws `ERR_REQUIRE_ASYNC_MODULE` and the synchronous `module.registerHooks` loader can't be registered from a `require()` context. A consumer (e.g. dd-trace) that `require()`s its loader entry silently falls back to the off-thread loader.

The top-level await was never necessary. `es-module-lexer`'s main entry resolves to a CommonJS build via its `require` export condition, and the `es-module-lexer/js` asm.js subpath is CommonJS too, so both parser builds load synchronously through `createRequire`. Selecting the parser synchronously drops the top-level await and keeps the module `require()`-able, without changing which build is used on either path.

## Why

The `--disallow-code-generation-from-strings` branch previously came in via `await import('es-module-lexer/js')` on the assumption that the asm.js build had no CommonJS variant. It does — the subpath's `default` condition points at a plain-CJS `dist/lexer.asm.js` — so `require()` loads it just as well, synchronously.

## Test plan

- [x] `test/get-esm-exports/require-sync-get-esm-exports.mjs` — new regression test: `require()` of `get-esm-exports.mjs` must not throw `ERR_REQUIRE_ASYNC_MODULE`, and the parser still lexes exports and `export *` re-exports. Fails on `main` with `ERR_REQUIRE_ASYNC_MODULE`, passes with this change.
- [x] Same regression test under `NODE_OPTIONS=--disallow-code-generation-from-strings` to cover the asm.js branch.
- [x] `test/get-esm-exports/*` and `test/register/*` (incl. the `v22.15-sync-register-hooks*` suites) pass.