### PR TITLE
perf: hoist generated wrapper binding runtime

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -214,9 +214,9 @@ function buildSetter (n, srcUrl, namespaceVar) {
   const objectKey = JSON.stringify(n)
   const reExportedName = n === 'default' ? n : objectKey
 
-  // `1` makes __bind fall back to namespace['default'] for the module.exports
-  // synthetic export, which builtins don't expose on the native ESM namespace.
-  const fallback = n === 'module.exports' ? ', 1' : ''
+  // Fall back to namespace['default'] for the module.exports synthetic export,
+  // which builtins don't expose on the native ESM namespace.
+  const useFallback = n === 'module.exports'
 
   // Builtins don't expose the module.exports synthetic name, so skip its re-export.
   const reExportLine = (n === 'module.exports' && (srcUrl.startsWith('node:') || builtinModules.includes(srcUrl)))
@@ -224,7 +224,7 @@ function buildSetter (n, srcUrl, namespaceVar) {
     : `export { ${variableName} as ${reExportedName} }`
 
   return `let ${variableName}
-__bind(${objectKey}, ${namespaceVar}, v => { ${variableName} = v }, () => ${variableName}${fallback})
+__binder.bind(${objectKey}, ${namespaceVar}, v => { ${variableName} = v }, () => ${variableName}, ${useFallback})
 ${reExportLine}`
 }
 
@@ -651,98 +651,16 @@ export function createHook (meta) {
     }
 
     return `
-import { register } from '${iitmURL}'
+import { register, ModuleBinder } from '${iitmURL}'
 import * as namespace from ${JSON.stringify(realUrl)}
 ${originImports}
-// Mimic a Module object (https://tc39.es/ecma262/#sec-module-namespace-objects).
-const _ = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })
-const set = {}
-const get = {}
-const __overridden = Object.create(null)
-let __pending = []
-
-function __makeUpdater (key, read, assign) {
-  return () => {
-    if (__overridden[key] === true) return true
-    try {
-      const v = read()
-      if (v !== undefined) {
-        assign(v)
-        return true
-      }
-      return false
-    } catch (err) {
-      if (err instanceof ReferenceError) return false
-      throw err
-    }
-  }
-}
-
-function __flushPendingOnce () {
-  if (__pending.length === 0) return
-  const next = []
-  for (const fn of __pending) {
-    // If it still throws ReferenceError, keep it for the (single) next attempt.
-    if (fn() !== true) next.push(fn)
-  }
-  __pending = next
-}
-
-function __bind (key, source, write, read, useFallback) {
-  const readSource = useFallback
-    ? () => source[key] ?? source['default']
-    : () => source[key]
-  __overridden[key] = false
-  let deferred = false
-  try {
-    const v = readSource()
-    write(v)
-    _[key] = v
-  } catch (err) {
-    if (!(err instanceof ReferenceError)) throw err
-    deferred = true
-  }
-  if (deferred || read() === undefined) {
-    __pending.push(__makeUpdater(key, readSource, (v) => { write(v); _[key] = v }))
-  }
-  set[key] = (v) => {
-    __overridden[key] = true
-    write(v)
-    return true
-  }
-  get[key] = read
-}
+const __binder = new ModuleBinder()
 
 ${Array.from(setters.values()).join('\n')}
 
-if (__pending.length > 0) {
-  queueMicrotask(() => {
-    __flushPendingOnce()
+__binder.flush()
 
-    if (__pending.length > 0) {
-      const __retryDelays = [0, 10, 50]
-      const __schedulePending = (i) => {
-        if (__pending.length === 0) return
-        if (i >= __retryDelays.length) {
-          // Give up: leave exports as-is to avoid unbounded retries.
-          __pending = []
-          return
-        }
-
-        const t = setTimeout(() => {
-          __flushPendingOnce()
-          __schedulePending(i + 1)
-        }, __retryDelays[i])
-        // Don't keep the process alive just for best-effort retries.
-        if (t && typeof t.unref === 'function') t.unref()
-      }
-
-      __schedulePending(0)
-    }
-  })
-}
-
-register(${JSON.stringify(realUrl)}, _, set, get, ${JSON.stringify(originalSpecifier)})
+register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.get, ${JSON.stringify(originalSpecifier)})
 `
   }
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -55,7 +55,143 @@ function register (name, namespace, set, get, specifier) {
   toHook.push([name, proxy, specifier])
 }
 
+// Delays (ms) for re-reading exports that were still in their temporal dead zone
+// when the wrapper first ran (circular imports). Retried on a microtask first,
+// then at these intervals; unref'd so best-effort retries never hold the process
+// open. Frozen once at module load rather than rebuilt per wrapper.
+const RETRY_DELAYS = [0, 10, 50]
+
+/**
+ * Per-wrapped-module state a generated wrapper builds once to expose its exports
+ * through iitm's proxy. Each wrapper holds a local binding per export plus
+ * `write`/`read` closures over it; `bind` seeds that binding from the real
+ * module and installs the proxy's `set`/`get` for the name, and `flush` resolves
+ * any export that was undefined (circular import) once it becomes available.
+ *
+ * This is the boilerplate the wrapper used to inline in full per module. Hoisting
+ * it here compiles it once instead of once per wrapped module and keeps the
+ * per-export bind call site monomorphic.
+ */
+class ModuleBinder {
+  // Mimics a Module namespace object (https://tc39.es/ecma262/#sec-module-namespace-objects).
+  namespace = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })
+  set = {}
+  get = {}
+  #overridden = Object.create(null)
+  #pending = []
+
+  /**
+   * Seeds `key` from `source` and installs its proxy accessors. A value that is
+   * undefined or throws `ReferenceError` (temporal dead zone during a circular
+   * import) is deferred to `flush`; any other throw propagates.
+   *
+   * @param {string} key The export name.
+   * @param {object} source The real module namespace to read the value from.
+   * @param {(value: unknown) => void} write Assigns the wrapper's local binding.
+   * @param {() => unknown} read Reads the wrapper's local binding.
+   * @param {boolean} useFallback Fall back to `source.default` (the synthetic
+   * `module.exports` name a builtin does not expose on its ESM namespace).
+   * @returns {void}
+   */
+  bind (key, source, write, read, useFallback) {
+    const readSource = useFallback
+      ? () => source[key] ?? source.default
+      : () => source[key]
+    this.#overridden[key] = false
+    let deferred = false
+    try {
+      const value = readSource()
+      write(value)
+      this.namespace[key] = value
+    } catch (error) {
+      if (!(error instanceof ReferenceError)) throw error
+      deferred = true
+    }
+    if (deferred || read() === undefined) {
+      this.#pending.push(this.#makeUpdater(key, readSource, write))
+    }
+    this.set[key] = (value) => {
+      this.#overridden[key] = true
+      write(value)
+      return true
+    }
+    this.get[key] = read
+  }
+
+  /**
+   * @param {string} key The export name to update.
+   * @param {() => unknown} readSource Reads the current value from the real module.
+   * @param {(value: unknown) => void} write Assigns the wrapper's local binding.
+   * @returns {() => boolean} Updater returning whether the value is now settled.
+   */
+  #makeUpdater (key, readSource, write) {
+    return () => {
+      if (this.#overridden[key] === true) return true
+      try {
+        const value = readSource()
+        if (value !== undefined) {
+          write(value)
+          this.namespace[key] = value
+          return true
+        }
+        return false
+      } catch (error) {
+        if (error instanceof ReferenceError) return false
+        // Only reached if a getter starts throwing a non-ReferenceError after the
+        // initial bind read already succeeded or deferred; surfaces in flush's
+        // microtask. Kept as-is from the inline wrapper.
+        /* c8 ignore next */
+        throw error
+      }
+    }
+  }
+
+  #flushOnce () {
+    const next = []
+    for (const updater of this.#pending) {
+      // If it still throws ReferenceError, keep it for the (single) next attempt.
+      if (updater() !== true) next.push(updater)
+    }
+    this.#pending = next
+  }
+
+  /**
+   * Resolves exports deferred by `bind` (undefined or TDZ at wrapper-eval time).
+   * Retries on a microtask, then at `RETRY_DELAYS`, giving up afterwards to avoid
+   * unbounded retries. A no-op when nothing was deferred.
+   *
+   * @returns {void}
+   */
+  flush () {
+    if (this.#pending.length === 0) return
+    queueMicrotask(() => {
+      this.#flushOnce()
+      this.#scheduleRetry(0)
+    })
+  }
+
+  /**
+   * @param {number} attempt Index into `RETRY_DELAYS` for the next retry.
+   * @returns {void}
+   */
+  #scheduleRetry (attempt) {
+    if (this.#pending.length === 0) return
+    if (attempt >= RETRY_DELAYS.length) {
+      // Give up: leave exports as-is to avoid unbounded retries.
+      this.#pending = []
+      return
+    }
+    const timer = setTimeout(() => {
+      this.#flushOnce()
+      this.#scheduleRetry(attempt + 1)
+    }, RETRY_DELAYS[attempt])
+    // Don't keep the process alive just for best-effort retries.
+    if (timer && typeof timer.unref === 'function') timer.unref()
+  }
+}
+
 exports.register = register
+exports.ModuleBinder = ModuleBinder
 exports.importHooks = importHooks
 exports.specifiers = specifiers
 exports.toHook = toHook

--- a/test/low-level/module-binder.mjs
+++ b/test/low-level/module-binder.mjs
@@ -1,7 +1,3 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
-
 // Unit-tests the ModuleBinder that generated wrappers use. The wrapper boilerplate
 // (seed export value, expose set/get, defer TDZ reads) lives here as real code
 // rather than emitted per wrapper, so it is exercised directly instead of only

--- a/test/low-level/module-binder.mjs
+++ b/test/low-level/module-binder.mjs
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+// Unit-tests the ModuleBinder that generated wrappers use. The wrapper boilerplate
+// (seed export value, expose set/get, defer TDZ reads) lives here as real code
+// rather than emitted per wrapper, so it is exercised directly instead of only
+// through the full loader.
+
+import { createRequire } from 'module'
+import { strictEqual, deepStrictEqual, throws } from 'assert'
+
+const require = createRequire(import.meta.url)
+const { ModuleBinder } = require('../../lib/register.js')
+
+// A wrapper models each export as a local binding plus write/read closures over
+// it; mimic one here.
+function makeSlot (initial) {
+  const slot = { value: initial }
+  return {
+    slot,
+    write: (value) => { slot.value = value },
+    read: () => slot.value
+  }
+}
+
+// bind seeds the current source value into the export and the module object.
+{
+  const binder = new ModuleBinder()
+  const source = { foo: 42 }
+  const { slot, write, read } = makeSlot(undefined)
+  binder.bind('foo', source, write, read, false)
+  strictEqual(slot.value, 42, 'bind seeds the export binding')
+  strictEqual(binder.namespace.foo, 42, 'bind seeds the module object')
+  strictEqual(binder.get.foo(), 42, 'get returns the current value')
+}
+
+// A hook writing through set overrides the value and wins over later updates.
+{
+  const binder = new ModuleBinder()
+  const source = { foo: 42 }
+  const { slot, write, read } = makeSlot(undefined)
+  binder.bind('foo', source, write, read, false)
+  strictEqual(binder.set.foo(99), true, 'set returns true')
+  strictEqual(slot.value, 99, 'set overrides the export binding')
+  binder.flush()
+  strictEqual(slot.value, 99, 'flush does not clobber an overridden value')
+}
+
+// useFallback reads source.default when the named export is missing.
+{
+  const binder = new ModuleBinder()
+  const source = { default: 7 }
+  const { slot, write, read } = makeSlot(undefined)
+  binder.bind('module.exports', source, write, read, true)
+  strictEqual(slot.value, 7, 'useFallback falls back to source.default')
+}
+
+// A value that is undefined at bind time is retried on the microtask once the
+// source provides it (the circular-import / TDZ path).
+{
+  const binder = new ModuleBinder()
+  const source = {}
+  const { slot, write, read } = makeSlot(undefined)
+  binder.bind('foo', source, write, read, false)
+  strictEqual(slot.value, undefined, 'no value yet')
+  source.foo = 5
+  binder.flush()
+  await Promise.resolve()
+  strictEqual(slot.value, 5, 'pending value resolved on flush microtask')
+}
+
+// A ReferenceError from the source read (TDZ) defers rather than throwing.
+{
+  const binder = new ModuleBinder()
+  let live = false
+  const source = { get foo () { if (!live) throw new ReferenceError('tdz'); return 8 } }
+  const { slot, write, read } = makeSlot(undefined)
+  binder.bind('foo', source, write, read, false)
+  strictEqual(slot.value, undefined, 'TDZ read deferred, no throw')
+  live = true
+  binder.flush()
+  await Promise.resolve()
+  strictEqual(slot.value, 8, 'deferred TDZ value resolved after it became live')
+}
+
+// Two binders keep independent state (set/get/namespace are per instance).
+{
+  const a = new ModuleBinder()
+  const b = new ModuleBinder()
+  a.bind('foo', { foo: 1 }, () => {}, () => 1, false)
+  b.bind('bar', { bar: 2 }, () => {}, () => 2, false)
+  deepStrictEqual(Object.keys(a.set), ['foo'])
+  deepStrictEqual(Object.keys(b.set), ['bar'])
+}
+
+// A source still in its dead zone on the retry read keeps the updater pending
+// (ReferenceError from the retried read is swallowed), then resolves.
+{
+  const binder = new ModuleBinder()
+  let stage = 0
+  const source = {
+    get foo () {
+      // Throw at bind time and on the first flush; resolve afterwards.
+      if (stage++ < 2) throw new ReferenceError('tdz')
+      return 11
+    }
+  }
+  const { slot, write, read } = makeSlot(undefined)
+  binder.bind('foo', source, write, read, false)
+  strictEqual(slot.value, undefined, 'still deferred after bind')
+  binder.flush()
+  await Promise.resolve()
+  strictEqual(slot.value, undefined, 'still deferred after first flush attempt')
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  strictEqual(slot.value, 11, 'resolved on a later retry once live')
+}
+
+// A non-ReferenceError thrown while seeding at bind time propagates.
+{
+  const binder = new ModuleBinder()
+  const source = { get foo () { throw new TypeError('boom') } }
+  const { write, read } = makeSlot(undefined)
+  throws(() => binder.bind('foo', source, write, read, false), TypeError)
+}


### PR DESCRIPTION
This significantly reduces loader startup cost by compiling the generated wrapper bind/retry machinery once instead of once per wrapper module. On the large mixed ESM/CJS app benchmark, wrapper source fell from 3572 KB to 1559 KB and IITM added overhead fell from 218.3 ms to 179.7 ms (-17.7%).
