### PR TITLE
fix: escape loader URL in generated wrappers

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -651,7 +651,7 @@ export function createHook (meta) {
     }
 
     return `
-import { register, ModuleBinder } from '${iitmURL}'
+import { register, ModuleBinder } from ${JSON.stringify(iitmURL)}
 import * as namespace from ${JSON.stringify(realUrl)}
 ${originImports}
 const __binder = new ModuleBinder()

--- a/test/register/v18.19-loader-url-escaping.mjs
+++ b/test/register/v18.19-loader-url-escaping.mjs
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2026 Datadog, Inc.
+
+import { strictEqual } from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { supportsSyncHooks } from '../../supports-sync-hooks.mjs'
+
+const packageRoot = fileURLToPath(new URL('../../', import.meta.url))
+const testDirectory = await mkdtemp(join(packageRoot, 'test', "iitm's-fixture-"))
+const installedPackageDirectory = join(testDirectory, 'node_modules', 'import-in-the-middle')
+
+try {
+  await mkdir(join(installedPackageDirectory, 'lib'), { recursive: true })
+
+  const packageFiles = [
+    'create-hook.mjs',
+    'hook.mjs',
+    'index.js',
+    'package.json',
+    'register-hooks.mjs',
+    'supports-sync-hooks.mjs',
+    'lib/get-esm-exports.mjs',
+    'lib/get-exports.mjs',
+    'lib/io.mjs',
+    'lib/register.js'
+  ]
+  const setupPromises = []
+  for (const filename of packageFiles) {
+    setupPromises.push(copyFile(join(packageRoot, filename), join(installedPackageDirectory, filename)))
+  }
+
+  setupPromises.push(writeFile(join(testDirectory, 'app.mjs'), `
+import { strictEqual } from 'node:assert/strict'
+import { readFile } from 'node:fs'
+
+strictEqual(readFile(), 'hooked')
+`))
+
+  const instruments = new Map([
+    ['async', `
+import { register } from 'node:module'
+import { Hook, createAddHookMessageChannel } from 'import-in-the-middle'
+
+const { registerOptions, waitForAllMessagesAcknowledged } = createAddHookMessageChannel()
+register('import-in-the-middle/hook.mjs', import.meta.url, registerOptions)
+
+/**
+ * @param {typeof import('node:fs')} exports
+ */
+function hookFs (exports) {
+  exports.readFile = () => 'hooked'
+}
+
+Hook(['fs'], hookFs)
+await waitForAllMessagesAcknowledged()
+`]
+  ])
+  if (supportsSyncHooks()) {
+    instruments.set('sync', `
+import { Hook } from 'import-in-the-middle'
+import { register } from 'import-in-the-middle/register-hooks.mjs'
+
+register({ include: ['fs'] })
+
+/**
+ * @param {typeof import('node:fs')} exports
+ */
+function hookFs (exports) {
+  exports.readFile = () => 'hooked'
+}
+
+Hook(['fs'], hookFs)
+`)
+  }
+
+  for (const [name, source] of instruments) {
+    const instrumentFilename = `instrument-${name}.mjs`
+    setupPromises.push(writeFile(join(testDirectory, instrumentFilename), source))
+  }
+  await Promise.all(setupPromises)
+
+  for (const name of instruments.keys()) {
+    const instrumentFilename = `instrument-${name}.mjs`
+    const result = spawnSync(
+      process.execPath,
+      ['--import', `./${instrumentFilename}`, './app.mjs'],
+      {
+        cwd: testDirectory,
+        encoding: 'utf8',
+        env: { ...process.env, IITM_TEST_FILE: '', NODE_OPTIONS: '' },
+        timeout: 10_000
+      }
+    )
+    if (result.error) throw result.error
+    strictEqual(result.status, 0, `${name} loader failed:\n${result.stderr}`)
+  }
+} finally {
+  await rm(testDirectory, { recursive: true, force: true })
+}

--- a/test/register/v18.19-loader-url-escaping.mjs
+++ b/test/register/v18.19-loader-url-escaping.mjs
@@ -1,7 +1,3 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
-//
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2026 Datadog, Inc.
-
 import { strictEqual } from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'


### PR DESCRIPTION
## Summary
Installation paths containing an apostrophe terminated the generated `lib/register.js` import specifier early, so intercepted modules failed to link. This serializes the loader URL as a JavaScript string literal and adds an installed-layout regression test for both loader modes.

## Test plan
Ran `npm run lint`, full `npm test`, and the path regression on Node 18.19.0, 22.22.0, 22.22.3, 24.18.0, and 26.3.1.

Fixes: https://github.com/nodejs/import-in-the-middle/issues/273