### PR TITLE
fix: delegate tagged modules to their owning loader

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -17,7 +17,6 @@ import { supportsSyncHooks } from './supports-sync-hooks.mjs'
 // this file's acorn / cjs-module-lexer dependency graph.
 export { supportsSyncHooks }
 
-const specifiers = new Map()
 const isWin = process.platform === 'win32'
 
 // Depth at which `processModule` starts tracking visited URLs to break an
@@ -36,6 +35,9 @@ const HANDLED_FORMATS = new Set([
   'builtin', 'module', 'commonjs', 'module-typescript', 'commonjs-typescript'
 ])
 const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
+
+/** @typedef {import('node:module').LoadHookContext} LoadContext */
+/** @typedef {import('node:module').LoadFnOutput} LoadResult */
 
 function hasIitm (url) {
   // Fast path: avoid URL parsing on the hot path when there's clearly no iitm.
@@ -404,7 +406,11 @@ function addIitm (url) {
   return urlObj.href
 }
 
+/**
+ * @param {{ url: string }} meta
+ */
 export function createHook (meta) {
+  const specifiers = new Map()
   let cachedResolve
   const iitmURL = new URL('lib/register.js', meta.url).toString()
   let includeModules, excludeModules
@@ -689,10 +695,19 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
     emitWarning(err)
   }
 
+  /**
+   * @param {string} url
+   * @param {LoadContext} context
+   * @param {(url: string, context?: Partial<LoadContext>) => LoadResult | Promise<LoadResult>} parentGetSource
+   */
   async function getSource (url, context, parentGetSource) {
     if (hasIitm(url)) {
       const realUrl = deleteIitm(url)
       const originalSpecifier = specifiers.get(realUrl)
+      if (originalSpecifier === undefined) {
+        specifiers.delete(url)
+        return parentGetSource(url, context)
+      }
 
       try {
         const { setters, originNamespaces } = await driveAsync(
@@ -713,10 +728,19 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
   // Synchronous counterpart to `getSource`, for `module.registerHooks`. Drives
   // `processModule` straight through; all bookkeeping and source generation is
   // shared with `getSource`.
+  /**
+   * @param {string} url
+   * @param {LoadContext} context
+   * @param {(url: string, context?: Partial<LoadContext>) => LoadResult} nextLoad
+   */
   function getSourceSync (url, context, nextLoad) {
     if (hasIitm(url)) {
       const realUrl = deleteIitm(url)
       const originalSpecifier = specifiers.get(realUrl)
+      if (originalSpecifier === undefined) {
+        specifiers.delete(url)
+        return nextLoad(url, context)
+      }
 
       try {
         const { setters, originNamespaces } = driveSync(

--- a/test/fixtures/async-coresidence-hook-copy.mjs
+++ b/test/fixtures/async-coresidence-hook-copy.mjs
@@ -1,0 +1,6 @@
+import { createHook } from '../../create-hook.mjs'
+
+const meta = { url: new URL('../../hook.mjs', import.meta.url).href }
+const { initialize, load, resolve } = createHook(meta)
+
+export { initialize, load, resolve }

--- a/test/fixtures/async-coresidence-register-copy.mjs
+++ b/test/fixtures/async-coresidence-register-copy.mjs
@@ -1,0 +1,7 @@
+import { register } from 'node:module'
+
+const targets = ['events', 'some-external-module', 'some-external-cjs-module']
+const mode = process.env.IITM_ASYNC_COPY_MODE
+const include = mode === 'include' ? targets : ['some-other-module']
+
+register('./async-coresidence-hook-copy.mjs', import.meta.url, { data: { include } })

--- a/test/fixtures/inspectable-create-hook.mjs
+++ b/test/fixtures/inspectable-create-hook.mjs
@@ -1,0 +1,25 @@
+import { Buffer } from 'node:buffer'
+import { readFileSync } from 'node:fs'
+
+const createHookUrl = new URL('../../create-hook.mjs', import.meta.url)
+let source = readFileSync(createHookUrl, 'utf8')
+
+/**
+ * @param {string} _match
+ * @param {string} relative
+ */
+function resolveImport (_match, relative) {
+  const absolute = new URL('../../' + relative.slice(2), import.meta.url).href
+  return `from ${JSON.stringify(absolute)}`
+}
+
+source = source.replace(/from '(\.\/[^']+)'/g, resolveImport)
+source = source.replace(
+  'return { initialize, load, resolve, resolveSync, loadSync, applyOptions }',
+  'return { initialize, load, resolve, resolveSync, loadSync, applyOptions, specifiers }'
+)
+
+const dataUrl = `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`
+const { createHook } = await import(dataUrl)
+
+export { createHook }

--- a/test/fixtures/sync-async-coresidence-app.mjs
+++ b/test/fixtures/sync-async-coresidence-app.mjs
@@ -1,0 +1,33 @@
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { EventEmitter } from 'node:events'
+
+import { foo as cjsFoo } from 'some-external-cjs-module'
+import { foo as esmFoo } from 'some-external-module'
+
+import { hits } from './sync-async-coresidence-state.mjs'
+
+if (process.env.IITM_EXPECT_HIT === '1') {
+  strictEqual(hits.length, 3)
+  const names = new Set()
+  for (const hit of hits) {
+    names.add(hit.name)
+    if (hit.name === 'events') {
+      strictEqual(hit.baseDir, undefined)
+    } else {
+      strictEqual(hit.baseDir, hit.name)
+    }
+  }
+  deepStrictEqual(names, new Set([
+    'events',
+    'some-external-cjs-module',
+    'some-external-module'
+  ]))
+  strictEqual(typeof EventEmitter, 'function')
+  strictEqual(cjsFoo, 'instrumented:some-external-cjs-module')
+  strictEqual(esmFoo, 'instrumented:some-external-module')
+} else {
+  deepStrictEqual(hits, [])
+  strictEqual(typeof EventEmitter, 'function')
+  strictEqual(cjsFoo, 'bar')
+  strictEqual(esmFoo, 'bar')
+}

--- a/test/fixtures/sync-async-coresidence-probe.mjs
+++ b/test/fixtures/sync-async-coresidence-probe.mjs
@@ -1,0 +1,19 @@
+import { basename } from 'node:path'
+
+import { Hook } from '../../index.js'
+import { hits } from './sync-async-coresidence-state.mjs'
+
+/**
+ * @param {Record<string, unknown>} exports
+ * @param {string} name
+ * @param {string | undefined} baseDir
+ */
+function onImport (exports, name, baseDir) {
+  hits.push({ name, baseDir: baseDir === undefined ? undefined : basename(baseDir) })
+  if (baseDir !== undefined) {
+    exports.foo = `instrumented:${name}`
+  }
+}
+
+// eslint-disable-next-line no-new
+new Hook(['events', 'some-external-module', 'some-external-cjs-module'], onImport)

--- a/test/fixtures/sync-async-coresidence-register-async.mjs
+++ b/test/fixtures/sync-async-coresidence-register-async.mjs
@@ -1,0 +1,7 @@
+import { register } from 'node:module'
+
+const targets = ['events', 'some-external-module', 'some-external-cjs-module']
+const mode = process.env.IITM_ASYNC_MODE
+const include = mode === 'include' ? targets : ['some-other-module']
+
+register('../../hook.mjs', import.meta.url, { data: { include } })

--- a/test/fixtures/sync-async-coresidence-register-sync.mjs
+++ b/test/fixtures/sync-async-coresidence-register-sync.mjs
@@ -1,0 +1,7 @@
+import { register } from '../../register-hooks.mjs'
+
+const targets = ['events', 'some-external-module', 'some-external-cjs-module']
+const mode = process.env.IITM_SYNC_MODE
+const include = mode === 'include' ? targets : ['some-other-module']
+
+register({ include })

--- a/test/fixtures/sync-async-coresidence-state.mjs
+++ b/test/fixtures/sync-async-coresidence-state.mjs
@@ -1,0 +1,1 @@
+export const hits = []

--- a/test/fixtures/sync-async-specifiers-map-cleanup-register-sync.mjs
+++ b/test/fixtures/sync-async-specifiers-map-cleanup-register-sync.mjs
@@ -1,0 +1,18 @@
+import * as nodeModule from 'node:module'
+
+import { createHook } from './inspectable-create-hook.mjs'
+
+const meta = { url: new URL('../../register-hooks.mjs', import.meta.url).href }
+const { applyOptions, loadSync, resolveSync, specifiers } = createHook(meta)
+
+applyOptions({ exclude: [/^node:(path|url)/] })
+
+process.once('exit', () => {
+  if (specifiers.size !== 0) {
+    // eslint-disable-next-line no-console
+    console.error(`synchronous specifiers map leak detected: ${Array.from(specifiers.keys()).join(', ')}`)
+    process.exitCode = 1
+  }
+})
+
+nodeModule.registerHooks({ resolve: resolveSync, load: loadSync })

--- a/test/loaders/specifiers-map-cleanup-loader.mjs
+++ b/test/loaders/specifiers-map-cleanup-loader.mjs
@@ -1,27 +1,10 @@
-import { readFileSync } from 'fs'
-import { Buffer } from 'buffer'
+import { createHook } from '../fixtures/inspectable-create-hook.mjs'
 
 // Loader used ONLY by `test/hook/specifiers-map-cleanup.mjs` (which is skipped on Node 18.0–18.18).
 // Keeping this file outside of `test/hook/` avoids having the test runner execute it directly.
 
-const createHookUrl = new URL('../../create-hook.mjs', import.meta.url)
-
-let src = readFileSync(createHookUrl, 'utf8')
-// We evaluate a modified copy of create-hook.mjs from a data: URL (to append
-// `export { specifiers }`). data: URLs have no hierarchical base, so rewrite
-// every relative `./...` import (./lib/*, ./supports-sync-hooks.mjs, ...) to an
-// absolute file URL first.
-src = src.replace(/from '(\.\/[^']+)'/g, (_match, relative) => {
-  const absolute = new URL('../../' + relative.slice(2), import.meta.url).href
-  return `from ${JSON.stringify(absolute)}`
-})
-src += '\nexport { specifiers }\n'
-
-const dataUrl = `data:text/javascript;base64,${Buffer.from(src).toString('base64')}`
-const { createHook, specifiers } = await import(dataUrl)
-
 const meta = { url: new URL('../../hook.mjs', import.meta.url).href }
-const { initialize, load, resolve } = createHook(meta)
+const { initialize, load, resolve, specifiers } = createHook(meta)
 
 process.on('exit', () => {
   if (specifiers.size !== 0) {

--- a/test/register/v18.19-async-async-coresidence.mjs
+++ b/test/register/v18.19-async-async-coresidence.mjs
@@ -1,0 +1,68 @@
+import { strictEqual } from 'node:assert'
+import { spawnSync } from 'node:child_process'
+
+const asyncPreload = './test/fixtures/sync-async-coresidence-register-async.mjs'
+const copyPreload = './test/fixtures/async-coresidence-register-copy.mjs'
+const probePreload = './test/fixtures/sync-async-coresidence-probe.mjs'
+const app = './test/fixtures/sync-async-coresidence-app.mjs'
+
+const scenarios = [
+  {
+    name: 'original then copy, both include',
+    preloads: [asyncPreload, copyPreload],
+    asyncMode: 'include',
+    copyMode: 'include',
+    expectHit: true
+  },
+  {
+    name: 'copy then original, both include',
+    preloads: [copyPreload, asyncPreload],
+    asyncMode: 'include',
+    copyMode: 'include',
+    expectHit: true
+  },
+  {
+    name: 'only inner original includes',
+    preloads: [asyncPreload, copyPreload],
+    asyncMode: 'include',
+    copyMode: 'skip',
+    expectHit: true
+  },
+  {
+    name: 'only outer copy includes',
+    preloads: [asyncPreload, copyPreload],
+    asyncMode: 'skip',
+    copyMode: 'include',
+    expectHit: true
+  },
+  {
+    name: 'neither includes',
+    preloads: [asyncPreload, copyPreload],
+    asyncMode: 'skip',
+    copyMode: 'skip',
+    expectHit: false
+  }
+]
+
+for (const scenario of scenarios) {
+  const args = ['--no-warnings']
+  for (const preload of scenario.preloads) {
+    args.push('--import', preload)
+  }
+  args.push('--import', probePreload, app)
+
+  const result = spawnSync(process.execPath, args, {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '',
+      IITM_ASYNC_MODE: scenario.asyncMode,
+      IITM_ASYNC_COPY_MODE: scenario.copyMode,
+      IITM_EXPECT_HIT: scenario.expectHit ? '1' : '0'
+    }
+  })
+
+  const output = `${scenario.name}\n${result.stderr || result.stdout}`
+  strictEqual(result.signal, null, output)
+  strictEqual(result.status, 0, output)
+}

--- a/test/register/v22.15-sync-async-coresidence.mjs
+++ b/test/register/v22.15-sync-async-coresidence.mjs
@@ -1,0 +1,89 @@
+import { strictEqual } from 'node:assert'
+import { spawnSync } from 'node:child_process'
+
+import { supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+const asyncPreload = './test/fixtures/sync-async-coresidence-register-async.mjs'
+const syncPreload = './test/fixtures/sync-async-coresidence-register-sync.mjs'
+const probePreload = './test/fixtures/sync-async-coresidence-probe.mjs'
+const app = './test/fixtures/sync-async-coresidence-app.mjs'
+
+const scenarios = [
+  {
+    name: 'async then sync, both include',
+    preloads: [asyncPreload, syncPreload],
+    asyncMode: 'include',
+    syncMode: 'include',
+    expectHit: true
+  },
+  {
+    name: 'sync then async, both include',
+    preloads: [syncPreload, asyncPreload],
+    asyncMode: 'include',
+    syncMode: 'include',
+    expectHit: true
+  },
+  {
+    name: 'async includes, sync does not',
+    preloads: [asyncPreload, syncPreload],
+    asyncMode: 'include',
+    syncMode: 'skip',
+    expectHit: true
+  },
+  {
+    name: 'sync registers first but only async includes',
+    preloads: [syncPreload, asyncPreload],
+    asyncMode: 'include',
+    syncMode: 'skip',
+    expectHit: true
+  },
+  {
+    name: 'sync includes, async does not',
+    preloads: [asyncPreload, syncPreload],
+    asyncMode: 'skip',
+    syncMode: 'include',
+    expectHit: true
+  },
+  {
+    name: 'sync registers first and only sync includes',
+    preloads: [syncPreload, asyncPreload],
+    asyncMode: 'skip',
+    syncMode: 'include',
+    expectHit: true
+  },
+  {
+    name: 'neither includes',
+    preloads: [asyncPreload, syncPreload],
+    asyncMode: 'skip',
+    syncMode: 'skip',
+    expectHit: false
+  }
+]
+
+for (const scenario of scenarios) {
+  const args = ['--no-warnings']
+  for (const preload of scenario.preloads) {
+    args.push('--import', preload)
+  }
+  args.push('--import', probePreload, app)
+
+  const result = spawnSync(process.execPath, args, {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '',
+      IITM_ASYNC_MODE: scenario.asyncMode,
+      IITM_SYNC_MODE: scenario.syncMode,
+      IITM_EXPECT_HIT: scenario.expectHit ? '1' : '0'
+    }
+  })
+
+  const output = `${scenario.name}\n${result.stderr || result.stdout}`
+  strictEqual(result.signal, null, output)
+  strictEqual(result.status, 0, output)
+}

--- a/test/register/v22.15-sync-async-specifiers-map-cleanup.mjs
+++ b/test/register/v22.15-sync-async-specifiers-map-cleanup.mjs
@@ -1,0 +1,24 @@
+import { strictEqual } from 'node:assert'
+import { spawnSync } from 'node:child_process'
+
+import { supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+const result = spawnSync(process.execPath, [
+  '--no-warnings',
+  '--loader',
+  './test/loaders/specifiers-map-cleanup-loader.mjs',
+  '--import',
+  './test/fixtures/sync-async-specifiers-map-cleanup-register-sync.mjs',
+  './test/fixtures/specifiers-map-cleanup-entry.mjs'
+], {
+  encoding: 'utf8',
+  env: { ...process.env, NODE_OPTIONS: '' }
+})
+
+strictEqual(result.signal, null)
+strictEqual(result.status, 0, result.stderr || result.stdout)


### PR DESCRIPTION
## Summary

When synchronous and asynchronous hooks coexist, the first load hook can receive a marker created by another hook. It previously tried to wrap that module without the original specifier, so instrumentation callbacks were skipped instead of reaching the hook that owned the marker.

Fixes: https://github.com/nodejs/import-in-the-middle/issues/274