### PR TITLE
fix: strip TypeScript after loaders normalize format

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -38,6 +38,7 @@ const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
 
 /** @typedef {import('node:module').LoadHookContext} LoadContext */
 /** @typedef {import('node:module').LoadFnOutput} LoadResult */
+/** @typedef {string | { specifier: string, format: 'module-typescript' | 'commonjs-typescript' }} SpecifierData */
 
 function hasIitm (url) {
   // Fast path: avoid URL parsing on the hot path when there's clearly no iitm.
@@ -410,6 +411,7 @@ function addIitm (url) {
  * @param {{ url: string }} meta
  */
 export function createHook (meta) {
+  /** @type {Map<string, SpecifierData>} */
   const specifiers = new Map()
   let cachedResolve
   const iitmURL = new URL('lib/register.js', meta.url).toString()
@@ -583,7 +585,11 @@ export function createHook (meta) {
       }
     }
 
-    specifiers.set(result.url, specifier)
+    // Preserve the format before an outer loader can normalize it.
+    const specifierData = result.format === 'module-typescript' || result.format === 'commonjs-typescript'
+      ? { specifier, format: result.format }
+      : specifier
+    specifiers.set(result.url, specifierData)
 
     return {
       url: addIitm(result.url),
@@ -703,18 +709,25 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
   async function getSource (url, context, parentGetSource) {
     if (hasIitm(url)) {
       const realUrl = deleteIitm(url)
-      const originalSpecifier = specifiers.get(realUrl)
-      if (originalSpecifier === undefined) {
+      const specifierData = specifiers.get(realUrl)
+      if (specifierData === undefined) {
         specifiers.delete(url)
         return parentGetSource(url, context)
       }
 
+      let originalSpecifier = specifierData
+      let processContext = context
+      if (typeof specifierData !== 'string') {
+        originalSpecifier = specifierData.specifier
+        processContext = { ...context, format: specifierData.format }
+      }
+
       try {
         const { setters, originNamespaces } = await driveAsync(
-          processModule({ srcUrl: realUrl, context }),
+          processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: parentGetSource }
         )
-        return { source: onWrapSuccess(realUrl, context, originalSpecifier, setters, originNamespaces) }
+        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, setters, originNamespaces) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         // Revert back to the non-iitm URL
@@ -736,18 +749,25 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
   function getSourceSync (url, context, nextLoad) {
     if (hasIitm(url)) {
       const realUrl = deleteIitm(url)
-      const originalSpecifier = specifiers.get(realUrl)
-      if (originalSpecifier === undefined) {
+      const specifierData = specifiers.get(realUrl)
+      if (specifierData === undefined) {
         specifiers.delete(url)
         return nextLoad(url, context)
       }
 
+      let originalSpecifier = specifierData
+      let processContext = context
+      if (typeof specifierData !== 'string') {
+        originalSpecifier = specifierData.specifier
+        processContext = { ...context, format: specifierData.format }
+      }
+
       try {
         const { setters, originNamespaces } = driveSync(
-          processModule({ srcUrl: realUrl, context }),
+          processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: nextLoad }
         )
-        return { source: onWrapSuccess(realUrl, context, originalSpecifier, setters, originNamespaces) }
+        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, setters, originNamespaces) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         url = realUrl

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -269,10 +269,6 @@ export function * getExports (url, context) {
   }
 
   try {
-    // Node hands the load hook the original TypeScript source, so strip the
-    // types before the JS parsers run, then treat the module as the JS it
-    // compiles to. Early type-stripping releases tag the format but lack the
-    // API; the un-stripped parse then fails cleanly into onWrapFailure.
     let moduleFormat = format
     if (format === 'module-typescript' || format === 'commonjs-typescript') {
       if (stripTypeScriptTypes !== undefined) {

--- a/test/fixtures/typescript-abstract-hook.mts
+++ b/test/fixtures/typescript-abstract-hook.mts
@@ -1,0 +1,7 @@
+export abstract class AbstractDelta {
+  abstract value: number
+}
+
+export class Delta {
+  value: number = 3
+}

--- a/test/fixtures/typescript-normalized-format-register-hooks.mjs
+++ b/test/fixtures/typescript-normalized-format-register-hooks.mjs
@@ -1,0 +1,32 @@
+import { deepStrictEqual, ok, strictEqual } from 'node:assert/strict'
+import { registerHooks } from 'node:module'
+
+import {
+  loadSync,
+  resolveSync
+} from '../loaders/typescript-normalized-format-loader.mjs'
+import Hook from '../../index.js'
+import { register } from '../../register-hooks.mjs'
+
+register()
+registerHooks({ load: loadSync, resolve: resolveSync })
+
+let esmExports
+
+/**
+ * @param {Record<string, unknown>} exports
+ * @param {string} name
+ */
+const hook = new Hook((exports, name) => {
+  if (name.endsWith('typescript-abstract-hook.mts')) {
+    esmExports = Object.keys(exports)
+  }
+})
+
+const esm = await import('./typescript-abstract-hook.mts')
+
+strictEqual(typeof esm.AbstractDelta, 'function')
+ok(esmExports)
+deepStrictEqual(esmExports.slice().sort(), ['AbstractDelta', 'Delta'])
+
+hook.unhook()

--- a/test/hook/v24-typescript-normalized-format.mjs
+++ b/test/hook/v24-typescript-normalized-format.mjs
@@ -1,0 +1,29 @@
+import { deepStrictEqual, ok, strictEqual } from 'node:assert/strict'
+import { register } from 'node:module'
+
+import Hook from '../../index.js'
+
+register('../loaders/typescript-normalized-format-loader.mjs', import.meta.url)
+
+let esmExports
+
+/**
+ * @param {Record<string, unknown>} exports
+ * @param {string} name
+ */
+const hook = new Hook((exports, name) => {
+  if (name.endsWith('typescript-abstract-hook.mts')) {
+    esmExports = Object.keys(exports)
+  }
+})
+
+const [esm] = await Promise.all([
+  import('../fixtures/typescript-abstract-hook.mts'),
+  import('../fixtures/something.mjs')
+])
+
+strictEqual(typeof esm.AbstractDelta, 'function')
+ok(esmExports)
+deepStrictEqual(esmExports.slice().sort(), ['AbstractDelta', 'Delta'])
+
+hook.unhook()

--- a/test/loaders/typescript-normalized-format-loader.mjs
+++ b/test/loaders/typescript-normalized-format-loader.mjs
@@ -1,0 +1,73 @@
+import { stripTypeScriptTypes } from 'node:module'
+
+const TARGET = '/test/fixtures/typescript-abstract-hook.mts'
+const textDecoder = new TextDecoder()
+
+/**
+ * @param {import('node:module').ResolveFnOutput} result
+ */
+function normalizeResolve (result) {
+  if (result.format === 'module-typescript' && result.url.includes(TARGET)) {
+    return { ...result, format: 'module' }
+  }
+
+  return result
+}
+
+/**
+ * @param {string} url
+ * @param {import('node:module').LoadFnOutput} result
+ */
+function normalizeLoad (url, result) {
+  if (
+    url.includes(TARGET) &&
+    result.source !== null &&
+    result.format === 'module'
+  ) {
+    const source = typeof result.source === 'string'
+      ? result.source
+      : textDecoder.decode(result.source)
+    return {
+      ...result,
+      source: stripTypeScriptTypes(source, { mode: 'strip' })
+    }
+  }
+
+  return result
+}
+
+/**
+ * @param {string} specifier
+ * @param {import('node:module').ResolveHookContext} context
+ * @param {import('node:module').ResolveFn} nextResolve
+ */
+export async function resolve (specifier, context, nextResolve) {
+  return normalizeResolve(await nextResolve(specifier, context))
+}
+
+/**
+ * @param {string} url
+ * @param {import('node:module').LoadHookContext} context
+ * @param {import('node:module').LoadFn} nextLoad
+ */
+export async function load (url, context, nextLoad) {
+  return normalizeLoad(url, await nextLoad(url, context))
+}
+
+/**
+ * @param {string} specifier
+ * @param {import('node:module').ResolveHookContext} context
+ * @param {import('node:module').ResolveFn} nextResolve
+ */
+export function resolveSync (specifier, context, nextResolve) {
+  return normalizeResolve(nextResolve(specifier, context))
+}
+
+/**
+ * @param {string} url
+ * @param {import('node:module').LoadHookContext} context
+ * @param {import('node:module').LoadFn} nextLoad
+ */
+export function loadSync (url, context, nextLoad) {
+  return normalizeLoad(url, nextLoad(url, context))
+}

--- a/test/register/v24-typescript-normalized-format.mjs
+++ b/test/register/v24-typescript-normalized-format.mjs
@@ -1,0 +1,11 @@
+import { strictEqual } from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const fixture = fileURLToPath(new URL('../fixtures/typescript-normalized-format-register-hooks.mjs', import.meta.url))
+const result = spawnSync(process.execPath, ['--no-warnings', fixture], {
+  encoding: 'utf8',
+  env: { ...process.env, NODE_OPTIONS: '' }
+})
+
+strictEqual(result.status, 0, result.stderr || result.stdout)


### PR DESCRIPTION
## Summary
TypeScript loaders such as tsx can normalize `module-typescript` to `module` after iitm resolves a module but before it reads exports. IITM then hands original TypeScript to es-module-lexer, which misreads `export abstract class` and generates a wrapper without the runtime export.

This preserves the original TypeScript format in the existing resolver metadata and restores it only while collecting exports. Non-TypeScript modules keep the string-only metadata path, with no URL scan or extra allocation.

Refs: https://github.com/guybedford/es-module-lexer/pull/228