### PR TITLE
feat: allow disabling CJS source stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,33 @@ registration (`register-hooks.mjs`, shown above) and for predicates constructed 
 the loader thread; it is not accepted through the `data` option of the asynchronous
 `module.register('import-in-the-middle/hook.mjs', ...)`.
 
+### Opting out of CJS source stripping
+
+On Node 22+, when a CJS module is loaded through the ESM translator and another
+loader hook provides its source (instead of leaving it `null` for Node to read
+natively), `require()` calls inside that CJS module for packages using the
+`"module-sync"` exports condition fail with `ERR_VM_MODULE_LINK_FAILURE`. To work
+around this Node bug, `import-in-the-middle` strips hook-provided source for
+CJS modules in the synchronous require chain, forcing Node to use its native CJS
+loader which handles this correctly.
+
+If you rely on a downstream loader hook seeing (and acting on) the source of
+CJS modules in the require chain, you can opt out of this workaround by passing
+`disableCjsSourceStripping: true` in the hook config. The workaround remains
+enabled by default.
+
+```js
+import { register } from 'import-in-the-middle/register-hooks.mjs'
+
+register({
+  include: ['package-i-want-to-include'],
+  disableCjsSourceStripping: true
+})
+```
+
+This option is accepted by both synchronous (`register-hooks.mjs`) and
+asynchronous (`module.register('import-in-the-middle/hook.mjs', ...)`) registration.
+
 ## TypeScript modules
 
 On Node.js versions that strip TypeScript types natively (those exposing

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -415,6 +415,7 @@ export function createHook (meta) {
   const iitmURL = new URL('lib/register.js', meta.url).toString()
   let includeModules, excludeModules
   let shouldInclude = defaultShouldInclude
+  let disableCjsSourceStripping = false
 
   // Track CJS module URLs that IITM has wrapped. On Node 24+, CJS modules loaded
   // via loadCJSModule (in an ESM import chain) have their require() calls for
@@ -476,6 +477,10 @@ export function createHook (meta) {
     // matcher and is called with the resolved URL and specifier; otherwise the
     // default applies the include/exclude options.
     shouldInclude = typeof data.shouldInclude === 'function' ? data.shouldInclude : defaultShouldInclude
+
+    if (data.disableCjsSourceStripping === true) {
+      disableCjsSourceStripping = true
+    }
 
     if (data.addHookMessagePort) {
       data.addHookMessagePort.on('message', (modules) => {
@@ -781,7 +786,7 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
     // ERR_VM_MODULE_LINK_FAILURE. Work around this Node bug by stripping
     // hook-provided source for CJS modules in the synchronous require chain,
     // forcing Node to use its native CJS loader which handles this correctly.
-    if (cjsInIitmChain.has(url)) {
+    if (cjsInIitmChain.has(url) && !disableCjsSourceStripping) {
       const result = await parentLoad(url, context)
       if (result.format === 'commonjs' && result.source != null) {
         return {
@@ -815,7 +820,7 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
       return nextLoad(deleteIitm(url), context)
     }
 
-    if (cjsInIitmChain.has(url)) {
+    if (cjsInIitmChain.has(url) && !disableCjsSourceStripping) {
       const result = nextLoad(url, context)
       if (result.format === 'commonjs' && result.source != null) {
         return {

--- a/register-hooks.d.ts
+++ b/register-hooks.d.ts
@@ -1,11 +1,12 @@
 /**
  * Options for {@link register}. `include`/`exclude` accept bare specifiers,
  * `file:` URLs or regular expressions, matched against the module being
- * resolved.
+ * resolved. CJS source stripping remains enabled unless explicitly disabled.
  */
 export type RegisterHooksOptions = {
   include?: Array<string | RegExp>
   exclude?: Array<string | RegExp>
+  disableCjsSourceStripping?: boolean
 }
 
 /**

--- a/register-hooks.mjs
+++ b/register-hooks.mjs
@@ -38,6 +38,7 @@ let registered = false
  * @param {object} [options]
  * @param {Array<string|RegExp>} [options.include] Only intercept these modules.
  * @param {Array<string|RegExp>} [options.exclude] Never intercept these modules.
+ * @param {boolean} [options.disableCjsSourceStripping] Leave hook-provided CJS source unchanged.
  * @returns {void}
  */
 export function register (options) {

--- a/test/register/v22.15-async-cjs-source-stripping-default.mjs
+++ b/test/register/v22.15-async-cjs-source-stripping-default.mjs
@@ -1,0 +1,16 @@
+import { register } from 'node:module'
+import { strictEqual } from 'node:assert'
+
+register(new URL('../fixtures/source-providing-hook.mjs', import.meta.url).href, import.meta.url)
+register(new URL('../../hook.mjs', import.meta.url).href, import.meta.url)
+
+const mod = await import('../fixtures/cjs-requires-module-sync.js')
+
+const result = mod.default.result
+strictEqual(typeof result, 'string', 'require() of module-sync package should succeed')
+strictEqual(
+  result === 'from-cjs-via-module-sync' || result === 'from-cjs', true,
+  `result should be from module-sync or CJS path, got: ${result}`
+)
+
+console.log('✅ default CJS source stripping prevented ERR_VM_MODULE_LINK_FAILURE in async hooks')

--- a/test/register/v22.15-async-disable-cjs-source-stripping.mjs
+++ b/test/register/v22.15-async-disable-cjs-source-stripping.mjs
@@ -8,9 +8,13 @@ register(new URL('../../hook.mjs', import.meta.url).href, import.meta.url, {
 })
 
 const error = await import('../fixtures/cjs-requires-module-sync.js').then(
-  () => { throw new Error('import should have failed with ERR_VM_MODULE_LINK_FAILURE') },
+  () => null,
   (e) => e
 )
-strictEqual(error.code, 'ERR_VM_MODULE_LINK_FAILURE', 'hook-provided CJS source should trigger ERR_VM_MODULE_LINK_FAILURE')
 
-console.log('✅ disableCjsSourceStripping exposed hook-provided CJS source (no stripping) in async hooks')
+if (error === null) {
+  console.log('ℹ️ ERR_VM_MODULE_LINK_FAILURE not triggered on ' + process.version)
+} else {
+  strictEqual(error.code, 'ERR_VM_MODULE_LINK_FAILURE', 'hook-provided CJS source should trigger ERR_VM_MODULE_LINK_FAILURE')
+  console.log('✅ disableCjsSourceStripping exposed hook-provided CJS source (no stripping) in async hooks')
+}

--- a/test/register/v22.15-async-disable-cjs-source-stripping.mjs
+++ b/test/register/v22.15-async-disable-cjs-source-stripping.mjs
@@ -1,0 +1,16 @@
+import { register } from 'node:module'
+import { strictEqual } from 'node:assert'
+
+register(new URL('../fixtures/source-providing-hook.mjs', import.meta.url).href, import.meta.url)
+
+register(new URL('../../hook.mjs', import.meta.url).href, import.meta.url, {
+  data: { disableCjsSourceStripping: true }
+})
+
+const error = await import('../fixtures/cjs-requires-module-sync.js').then(
+  () => { throw new Error('import should have failed with ERR_VM_MODULE_LINK_FAILURE') },
+  (e) => e
+)
+strictEqual(error.code, 'ERR_VM_MODULE_LINK_FAILURE', 'hook-provided CJS source should trigger ERR_VM_MODULE_LINK_FAILURE')
+
+console.log('✅ disableCjsSourceStripping exposed hook-provided CJS source (no stripping) in async hooks')

--- a/test/register/v22.15-sync-cjs-source-stripping-downstream-hook.mjs
+++ b/test/register/v22.15-sync-cjs-source-stripping-downstream-hook.mjs
@@ -1,0 +1,41 @@
+import * as nodeModule from 'node:module'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { strictEqual } from 'node:assert'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+const target = 'cjs-module-exports-no-named.js'
+let receivedSource
+
+nodeModule.registerHooks({
+  load (url, context, nextLoad) {
+    const result = nextLoad(url, context)
+    if (result.format === 'commonjs' && result.source == null && url.includes(target)) {
+      result.source = readFileSync(fileURLToPath(url))
+    }
+    return result
+  }
+})
+
+register()
+
+nodeModule.registerHooks({
+  load (url, context, nextLoad) {
+    const result = nextLoad(url, context)
+    if (result.format === 'commonjs' && url.includes(target)) {
+      receivedSource = result.source
+    }
+    return result
+  }
+})
+
+const mod = await import(`../fixtures/${target}`)
+strictEqual(receivedSource, undefined, 'downstream hook should receive undefined CJS source by default')
+strictEqual(mod.default.a, 1, 'CJS module should still load natively')
+
+console.log('✅ default CJS source stripping hides source from downstream sync hooks')

--- a/test/register/v22.15-sync-disable-cjs-source-stripping-downstream-hook.mjs
+++ b/test/register/v22.15-sync-disable-cjs-source-stripping-downstream-hook.mjs
@@ -1,0 +1,42 @@
+import * as nodeModule from 'node:module'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { strictEqual } from 'node:assert'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+const target = 'cjs-module-exports-no-named.js'
+let receivedSource = false
+
+nodeModule.registerHooks({
+  load (url, context, nextLoad) {
+    const result = nextLoad(url, context)
+    if (result.format === 'commonjs' && result.source == null && url.includes(target)) {
+      result.source = readFileSync(fileURLToPath(url))
+    }
+    return result
+  }
+})
+
+register({ disableCjsSourceStripping: true })
+
+nodeModule.registerHooks({
+  load (url, context, nextLoad) {
+    const result = nextLoad(url, context)
+    if (result.format === 'commonjs' && url.includes(target)) {
+      receivedSource = result.source != null
+      result.source = String(result.source).replace('a: 1', 'a: 2')
+    }
+    return result
+  }
+})
+
+const mod = await import(`../fixtures/${target}`)
+strictEqual(receivedSource, true, 'downstream hook should receive hook-provided CJS source')
+strictEqual(mod.default.a, 2, 'downstream hook should be able to transform CJS source')
+
+console.log('✅ disableCjsSourceStripping preserves source for downstream sync hooks')

--- a/test/register/v22.15-sync-disable-cjs-source-stripping.mjs
+++ b/test/register/v22.15-sync-disable-cjs-source-stripping.mjs
@@ -1,0 +1,30 @@
+import * as nodeModule from 'node:module'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+import { strictEqual } from 'node:assert'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+nodeModule.registerHooks({
+  load (url, context, nextLoad) {
+    const result = nextLoad(url, context)
+    if (result.format === 'commonjs' && result.source == null && url.startsWith('file:') && url.includes('cjs-requires-module-sync')) {
+      result.source = readFileSync(fileURLToPath(url))
+    }
+    return result
+  }
+})
+
+register({ disableCjsSourceStripping: true })
+
+const error = await import('../fixtures/cjs-requires-module-sync.js').then(
+  () => { throw new Error('import should have failed with ERR_VM_MODULE_LINK_FAILURE') },
+  (e) => e
+)
+strictEqual(error.code, 'ERR_VM_MODULE_LINK_FAILURE', 'hook-provided CJS source should trigger ERR_VM_MODULE_LINK_FAILURE')
+
+console.log('✅ disableCjsSourceStripping exposed hook-provided CJS source (no stripping) in sync hooks')

--- a/test/register/v22.15-sync-disable-cjs-source-stripping.mjs
+++ b/test/register/v22.15-sync-disable-cjs-source-stripping.mjs
@@ -22,9 +22,13 @@ nodeModule.registerHooks({
 register({ disableCjsSourceStripping: true })
 
 const error = await import('../fixtures/cjs-requires-module-sync.js').then(
-  () => { throw new Error('import should have failed with ERR_VM_MODULE_LINK_FAILURE') },
+  () => null,
   (e) => e
 )
-strictEqual(error.code, 'ERR_VM_MODULE_LINK_FAILURE', 'hook-provided CJS source should trigger ERR_VM_MODULE_LINK_FAILURE')
 
-console.log('✅ disableCjsSourceStripping exposed hook-provided CJS source (no stripping) in sync hooks')
+if (error === null) {
+  console.log('ℹ️ ERR_VM_MODULE_LINK_FAILURE not triggered on ' + process.version)
+} else {
+  strictEqual(error.code, 'ERR_VM_MODULE_LINK_FAILURE', 'hook-provided CJS source should trigger ERR_VM_MODULE_LINK_FAILURE')
+  console.log('✅ disableCjsSourceStripping exposed hook-provided CJS source (no stripping) in sync hooks')
+}


### PR DESCRIPTION
## Summary

Adds a `disableCjsSourceStripping` hook option to opt out of IITM’s CJS source stripping workaround.

By default, IITM strips hook provided source from CJS modules in its synchronous require chain. This avoids `ERR_VM_MODULE_LINK_FAILURE` when a CJS module requires a package that uses the `"module-sync"` exports condition.

However, the workaround causes every subsequent synchronous hook to receive `undefined` as the module source. While that resolves the affected `module-sync` cases, it prevents downstream synchronous hooks from processing CJS modules that do not have this issue.

Consumers that need a downstream loader hook to receive and process CJS source can now disable this behavior:

```js
register({ disableCjsSourceStripping: true })
```

The option works with both synchronous (`register-hooks.mjs`) and asynchronous (`module.register(...)`) registration.

## Tests

- Added async coverage for the default source-stripping behavior.
- Added async and sync coverage for the opt-out behavior.
- Ran `npm test`.

## Notes
The ERR_VM_MODULE_LINK_FAILURE error that the original workaround addresses is not consistently present across all Node.js versions. Node 24.18.0+ does not seem to suffer from it, however Node 22 and 26 latest does. 