### PR TITLE
perf: reduce ESM wrapper allocations

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -5,10 +5,7 @@
 import { URL, fileURLToPath } from 'url'
 import { inspect } from 'util'
 import { builtinModules } from 'module'
-import {
-  getExports,
-  hasModuleExportsCJSDefault
-} from './lib/get-exports.mjs'
+import { getExports } from './lib/get-exports.mjs'
 import { RESOLVE, driveSync, driveAsync } from './lib/io.mjs'
 import { supportsSyncHooks } from './supports-sync-hooks.mjs'
 
@@ -29,8 +26,8 @@ const STAR_CYCLE_DEPTH = 100
 // FIXME: Typescript extensions are added temporarily until we find a better
 // way of supporting arbitrary extensions
 const EXTENSION_RE = /\.(js|mjs|cjs|ts|mts|cts)$/
-// The `-typescript` formats are listed unconditionally; getExports strips the
-// types when the runtime supports it and otherwise falls back to onWrapFailure.
+// The full es-module-lexer build handles erasable TypeScript syntax in the same
+// pass as JavaScript, so the `-typescript` formats use the normal export path.
 const HANDLED_FORMATS = new Set([
   'builtin', 'module', 'commonjs', 'module-typescript', 'commonjs-typescript'
 ])
@@ -39,6 +36,12 @@ const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
 /** @typedef {import('node:module').LoadHookContext} LoadContext */
 /** @typedef {import('node:module').LoadFnOutput} LoadResult */
 /** @typedef {string | { specifier: string, format: 'module-typescript' | 'commonjs-typescript' }} SpecifierData */
+/** @typedef {{ name: string, origin: string }} StarBinding */
+/**
+ * @typedef {object} ProcessResult
+ * @property {string[] | Map<string, string | StarBinding>} bindings
+ * @property {Map<string, string> | undefined} origins
+ */
 
 function hasIitm (url) {
   // Fast path: avoid URL parsing on the hot path when there's clearly no iitm.
@@ -80,19 +83,6 @@ function deleteIitm (url) {
   }
   Error.stackTraceLimit = stackTraceLimit
   return resultUrl
-}
-
-/**
- * Determines if a specifier represents an export all ESM line.
- * Note that the expected `line` isn't 100% valid ESM. It is derived
- * from the `getExports` function wherein we have recognized the true
- * line and re-mapped it to one we expect.
- *
- * @param {string} line
- * @returns {boolean}
- */
-function isStarExportLine (line) {
-  return /^\* from /.test(line)
 }
 
 function isBareSpecifier (specifier) {
@@ -193,46 +183,24 @@ function emitWarning (err) {
 }
 
 /**
- * Builds the setter/getter/re-export block injected into the wrapper module for
- * a single named export. This is pure string generation, identical regardless
- * of how the loader is driven, so both the synchronous and asynchronous paths
- * share it.
- *
- * The value is read from `namespaceVar`, the wrapper's namespace binding for the
- * module that *defines* the export. For a module's own exports that is the
- * wrapped module itself; for a name re-exported through `export *` it is the
- * leaf that declares it. Reading from the defining module rather than the
- * aggregating one keeps the value resolvable when the same binding reaches the
- * aggregator through more than one re-export chain — Node sees those chains as
- * distinct wrapper modules and leaves the name ambiguous (hence `undefined`) on
- * the aggregate namespace, while the defining module always holds it (#171).
- *
- * @param {string} n The exported name.
- * @param {string} srcUrl The URL of the module the export belongs to.
- * @param {string} namespaceVar The wrapper binding holding `srcUrl`'s namespace.
- * @returns {string}
+ * @param {string} name The exported name.
+ * @param {string} sourceUrl The URL of the module that defines the export.
  */
-function buildSetter (n, srcUrl, namespaceVar) {
-  const variableName = `$${n.replace(/[^a-zA-Z0-9_$]/g, '_')}`
-  const objectKey = JSON.stringify(n)
-  const reExportedName = n === 'default' ? n : objectKey
-
-  // Fall back to namespace['default'] for the module.exports synthetic export,
-  // which builtins don't expose on the native ESM namespace.
-  const useFallback = n === 'module.exports'
-
-  // Builtins don't expose the module.exports synthetic name, so skip its re-export.
-  const reExportLine = (n === 'module.exports' && (srcUrl.startsWith('node:') || builtinModules.includes(srcUrl)))
-    ? ''
-    : `export { ${variableName} as ${reExportedName} }`
-
-  return `let ${variableName}
-__binder.bind(${objectKey}, ${namespaceVar}, v => { ${variableName} = v }, () => ${variableName}, ${useFallback})
-${reExportLine}`
+function shouldReexport (name, sourceUrl) {
+  return name !== 'module.exports' ||
+    (!sourceUrl.startsWith('node:') && !builtinModules.includes(sourceUrl))
 }
 
 /**
- * Processes a module's exports and builds a set of setter blocks.
+ * @param {string} name The exported name.
+ * @param {string} sourceUrl The URL of the module that defines the export.
+ */
+function shouldExcludeExport (name, sourceUrl) {
+  return name === 'default' || !shouldReexport(name, sourceUrl)
+}
+
+/**
+ * Processes a module's exports and builds its wrapper bindings.
  *
  * Written as a "sans-io" generator (see `lib/io.mjs`): instead of calling the
  * loader's resolve/load hooks directly it `yield`s `[RESOLVE, ...]` to resolve
@@ -243,7 +211,7 @@ ${reExportLine}`
  *
  * @param {object} params
  * @param {string} params.srcUrl The full URL to the module to process.
- * @param {object} params.context Provided by the loaders API.
+ * @param {LoadContext} params.context Provided by the loaders API.
  * @param {boolean} [params.excludeDefault = false] Exclude the default export.
  * @param {number} [params.depth = 0] Star-re-export recursion depth. Used to
  * detect `export *` cycles (`a` re-exports `b`, `b` re-exports `a`) cheaply:
@@ -253,23 +221,31 @@ ${reExportLine}`
  * created lazily once `depth` crosses {@link STAR_CYCLE_DEPTH}. A URL is added
  * before descending into its subtree and removed once that subtree finishes, so
  * it tracks the active path rather than every URL ever visited.
- * @param {Map<string, string>} [params.originNamespaces] Shared registry mapping
- * a defining-module URL to the wrapper namespace alias a same-origin `export *`
- * collision must read it from. Absent until the first such collision; then
- * threaded through the recursion so one defining module yields one alias and
- * {@link buildWrapperSource} imports each once. Only `*`-collided names use it;
- * every other export reads from the wrapped module's own `namespace`.
- *
- * @returns {Generator<Array, { setters: Map<string, string>, origins: (Map<string, string> | undefined), originNamespaces: (Map<string, string> | undefined) }>}
+ * @returns {Generator<Array, ProcessResult>}
  * A generator that yields I/O operations and ultimately returns the shimmed
- * setters for all the exports from the module and any transitive export all
+ * bindings for all the exports from the module and any transitive export all
  * modules. `origins` (the defining module per `*`-sourced name) is `undefined`
- * for a module with no `export *`; `originNamespaces` stays `undefined` unless a
- * same-origin `*` collision actually needed an alias.
+ * for a module with no `export *`.
  */
-function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen, originNamespaces }) {
-  const exportNames = yield * getExports(srcUrl, context)
-  const setters = new Map()
+function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen }) {
+  const { exportNames, starReexports } = yield * getExports(srcUrl, context)
+
+  // Most modules have no export star. Keep that path array-backed so it pays
+  // neither merge bookkeeping nor a Map lookup for each direct export.
+  if (starReexports === undefined) {
+    if (!excludeDefault) {
+      return { bindings: exportNames, origins: undefined }
+    }
+
+    const bindings = []
+    for (const name of exportNames) {
+      if (shouldExcludeExport(name, srcUrl)) continue
+      bindings.push(name)
+    }
+    return { bindings, origins: undefined }
+  }
+
+  const bindings = new Map()
 
   // Maps each live `*`-sourced name to the module that defined it. Its keys
   // double as "this name came from a `*` re-export" (so an explicit export can
@@ -278,127 +254,94 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
   // single Map carries both facts so a star with no collision pays one structure
   // and one write per name, not two.
   let starOrigins
+  let ambiguousStars
+  let firstStarUrl
+  let processedStarUrls
 
-  // A name pulled in through more than one `export *` chain that all bottom out
-  // at the same module stays exported (ECMAScript ResolveExport;
-  // tc39/ecma262#3715), but the *aggregate* namespace this wrapper imports drops
-  // it: under iitm the chains are distinct wrapped modules, so Node sees the
-  // re-export as ambiguous and the name reads back undefined. Only those names
-  // must instead read from their defining module's own namespace, which always
-  // holds the value. `originNamespaces` maps such a defining module to the alias
-  // the wrapper imports for it; it is allocated on the first surviving
-  // collision, so a module without one emits no extra import (#171).
-  const ensureOriginNamespace = (origin) => {
-    originNamespaces ??= new Map()
-    let alias = originNamespaces.get(origin)
-    if (alias === undefined) {
-      alias = `__ns${originNamespaces.size}`
-      originNamespaces.set(origin, alias)
-    }
-    return alias
+  for (const name of exportNames) {
+    if (excludeDefault && shouldExcludeExport(name, srcUrl)) continue
+    bindings.set(name, name)
   }
 
-  const addSetter = (name, setter, isStarExport, origin) => {
-    if (setters.has(name)) {
-      if (isStarExport) {
-        // `starOrigins.has(name)` means the existing entry also came from a `*`
-        // re-export (an explicit export would not be tracked here).
-        if (starOrigins.has(name)) {
+  for (const { specifier, parentURL } of starReexports) {
+    // Relative paths need to be resolved relative to the module declaring the star.
+    const newSpecifier = isBareSpecifier(specifier) ? specifier : new URL(specifier, parentURL).href
+    // We need to resolve bare specifiers to a full URL. We also need to
+    // resolve all sub-modules to get the `format`. We can't rely on the
+    // parent's `format` to know if this sub-module is ESM or CJS!
+    const result = yield [RESOLVE, newSpecifier, { parentURL }]
+
+    // Most star modules have one target. Defer the collection until a second
+    // distinct target while still ignoring repeated declarations.
+    if (firstStarUrl === undefined) {
+      firstStarUrl = result.url
+    } else if (processedStarUrls === undefined) {
+      if (result.url === firstStarUrl) continue
+      processedStarUrls = [firstStarUrl, result.url]
+    } else {
+      if (processedStarUrls.includes(result.url)) continue
+      processedStarUrls.push(result.url)
+    }
+
+    // First `*` re-export: allocate the origin bookkeeping lazily.
+    starOrigins ??= new Map()
+
+    // `export *` graphs are normally only a handful of levels deep. A cycle
+    // (`a` re-exports `b`, `b` re-exports `a`) instead recurses without bound
+    // and exhausts memory. Rather than track every URL on the common shallow
+    // path, only start recording once the depth is implausibly large for a
+    // real graph; from there a re-export pointing back at a module already on
+    // the recursion stack is the cycle, and is skipped (its exports are
+    // collected by the in-progress ancestor frame). `seen` mirrors the stack,
+    // not every URL visited: a module reached and fully processed through one
+    // sibling branch must stay reachable through a later, more direct branch,
+    // so it is removed again once its subtree finishes.
+    if (depth >= STAR_CYCLE_DEPTH) {
+      seen ??= new Set()
+      if (seen.has(result.url)) continue
+      seen.add(result.url)
+    }
+
+    try {
+      const sub = yield * processModule({
+        srcUrl: result.url,
+        context: { ...context, format: result.format },
+        excludeDefault: true,
+        depth: depth + 1,
+        seen
+      })
+
+      for (const binding of sub.bindings.values()) {
+        const directName = typeof binding === 'string' ? binding : undefined
+        const name = directName ?? binding.name
+        if (ambiguousStars?.has(name)) continue
+
+        const origin = directName === undefined ? binding.origin : sub.origins?.get(name) ?? result.url
+        if (bindings.has(name)) {
+          // An explicit export shadows every star re-export.
+          if (!starOrigins.has(name)) continue
+
           if (starOrigins.get(name) === origin) {
-            // The same binding reached through two `*` re-export chains. It
-            // stays exported, but the aggregate namespace dropped it, so point
-            // its setter at the defining module's namespace instead.
-            setters.set(name, buildSetter(name, origin, ensureOriginNamespace(origin)))
+            // IITM's aggregate namespace sees the wrapped paths as ambiguous.
+            // Retain the defining URL so source generation can import it once.
+            bindings.set(name, { name, origin })
           } else {
-            // Genuinely ambiguous: two `*` re-exports name it from different
-            // modules. Per ResolveExport the name is excluded entirely.
-            setters.delete(name)
+            bindings.delete(name)
             starOrigins.delete(name)
+            ambiguousStars ??= new Set()
+            ambiguousStars.add(name)
           }
+        } else {
+          starOrigins.set(name, origin)
+          bindings.set(name, binding)
         }
-        // An explicit export already shadows the `*` re-export; leave it.
       }
-    } else {
-      if (isStarExport) {
-        starOrigins.set(name, origin)
-      }
-
-      setters.set(name, setter)
+    } finally {
+      seen?.delete(result.url)
     }
   }
 
-  for (const n of exportNames) {
-    if (excludeDefault) {
-      const isDefault = n === 'default' ||
-        (
-          n === 'module.exports' &&
-          context.format === 'commonjs' &&
-          hasModuleExportsCJSDefault
-        )
-
-      if (isDefault) continue
-    }
-
-    if (isStarExportLine(n) === true) {
-      const [, modFile] = n.split('* from ')
-
-      // Relative paths need to be resolved relative to the parent module
-      const newSpecifier = isBareSpecifier(modFile) ? modFile : new URL(modFile, srcUrl).href
-      // We need to resolve bare specifiers to a full URL. We also need to
-      // resolve all sub-modules to get the `format`. We can't rely on the
-      // parent's `format` to know if this sub-module is ESM or CJS!
-      const result = yield [RESOLVE, newSpecifier, { parentURL: srcUrl }]
-
-      // First `*` re-export: allocate the origin bookkeeping lazily.
-      starOrigins ??= new Map()
-
-      // `export *` graphs are normally only a handful of levels deep. A cycle
-      // (`a` re-exports `b`, `b` re-exports `a`) instead recurses without bound
-      // and exhausts memory. Rather than track every URL on the common shallow
-      // path, only start recording once the depth is implausibly large for a
-      // real graph; from there a re-export pointing back at a module already on
-      // the recursion stack is the cycle, and is skipped (its exports are
-      // collected by the in-progress ancestor frame). `seen` mirrors the stack,
-      // not every URL visited: a module reached and fully processed through one
-      // sibling branch must stay reachable through a later, more direct branch,
-      // so it is removed again once its subtree finishes.
-      if (depth >= STAR_CYCLE_DEPTH) {
-        seen ??= new Set()
-        if (seen.has(result.url)) continue
-        seen.add(result.url)
-      }
-
-      try {
-        const sub = yield * processModule({
-          srcUrl: result.url,
-          context: { ...context, format: result.format },
-          excludeDefault: true,
-          depth: depth + 1,
-          seen,
-          originNamespaces
-        })
-
-        // Adopt any registry a nested `export *` minted before processing this
-        // child's results, so a collision detected here extends the same Map the
-        // child's setters already reference (one alias per defining module across
-        // the whole tree) rather than orphaning the child's into a second Map.
-        originNamespaces ??= sub.originNamespaces
-
-        // Star targets build their setters against `namespace` like any other
-        // module; only a surviving same-origin collision (in addSetter) rewrites
-        // the affected name to read from its defining module's alias.
-        for (const [name, setter] of sub.setters) {
-          addSetter(name, setter, true, sub.origins?.get(name) ?? result.url)
-        }
-      } finally {
-        seen?.delete(result.url)
-      }
-    } else {
-      addSetter(n, buildSetter(n, srcUrl, 'namespace'), false)
-    }
-  }
-
-  return { setters, origins: starOrigins, originNamespaces }
+  return { bindings, origins: starOrigins }
 }
 
 function addIitm (url) {
@@ -651,47 +594,100 @@ export function createHook (meta) {
     return finishResolve(result, specifier, context, parentURL)
   }
 
-  // Builds the wrapper module source that re-exports the real module through
-  // iitm's proxy. Pure string generation shared by the asynchronous and
-  // synchronous `load` paths.
-  function buildWrapperSource (realUrl, setters, originalSpecifier, originNamespaces) {
+  /**
+   * Builds the wrapper module source shared by the asynchronous and synchronous hooks.
+   *
+   * @param {string} realUrl The URL of the wrapped module.
+   * @param {string[] | Map<string, string | StarBinding>} bindings Its exported bindings.
+   * @param {string} originalSpecifier The specifier used to import the module.
+   */
+  function buildWrapperSource (realUrl, bindings, originalSpecifier) {
     // The wrapped module imports its namespace as `namespace`, which serves
     // every export but the ones a same-origin `export *` collision forced onto
     // their defining module (#171): the aggregate namespace drops those as
     // ambiguous under iitm, so each such defining module gets its own alias the
-    // wrapper imports. Absent the registry (no such collision) nothing is added.
+    // wrapper imports. Without such a collision nothing is added.
     let originImports = ''
-    if (originNamespaces !== undefined) {
-      for (const [originUrl, alias] of originNamespaces) {
-        originImports += `import * as ${alias} from ${JSON.stringify(originUrl)}\n`
+    let originNamespaces
+    let declarationNames = ''
+    let bindingNames = ''
+    let bindingSources
+    let exportSpecifiers = ''
+    let writeCases = ''
+    let index = 0
+    for (const binding of bindings.values()) {
+      const directName = typeof binding === 'string' ? binding : undefined
+      const name = directName ?? binding.name
+      let namespaceName = 'namespace'
+      if (directName === undefined) {
+        originNamespaces ??= new Map()
+        namespaceName = originNamespaces.get(binding.origin)
+        if (namespaceName === undefined) {
+          namespaceName = `__ns${originNamespaces.size}`
+          originNamespaces.set(binding.origin, namespaceName)
+          originImports += `import * as ${namespaceName} from ${JSON.stringify(binding.origin)}\n`
+        }
+      }
+      const variableName = `$${index}`
+      const objectKey = JSON.stringify(name)
+      declarationNames += declarationNames === '' ? variableName : `, ${variableName}`
+      bindingNames += bindingNames === '' ? objectKey : `, ${objectKey}`
+      if (bindingSources !== undefined) bindingSources += ', '
+      if (namespaceName !== 'namespace') {
+        bindingSources ??= 'undefined, '.repeat(index)
+        bindingSources += namespaceName
+      } else if (bindingSources !== undefined) {
+        bindingSources += 'undefined'
+      }
+      writeCases += `    case ${index++}: ${variableName} = value; break\n`
+      if (shouldReexport(name, realUrl)) {
+        const exportName = name === 'default' ? name : objectKey
+        exportSpecifiers += exportSpecifiers === ''
+          ? `${variableName} as ${exportName}`
+          : `, ${variableName} as ${exportName}`
       }
     }
+    const binder = declarationNames === ''
+      ? 'const __binder = new ModuleBinder(namespace)\n'
+      : `let ${declarationNames}
+function __write (index, value) {
+  switch (index) {
+${writeCases}  }
+}
+const __binder = new ModuleBinder(namespace, [${bindingNames}], __write${bindingSources === undefined
+  ? ''
+  : `, [${bindingSources}]`})
+`
+    const reexports = exportSpecifiers === '' ? '' : `export { ${exportSpecifiers} }\n`
 
     return `
 import { register, ModuleBinder } from ${JSON.stringify(iitmURL)}
 import * as namespace from ${JSON.stringify(realUrl)}
 ${originImports}
-const __binder = new ModuleBinder()
-
-${Array.from(setters.values()).join('\n')}
+${binder}
+${reexports}
 
 __binder.flush()
 
-register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.get, ${JSON.stringify(originalSpecifier)})
+register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifier)})
 `
   }
 
-  // Bookkeeping shared by the async and sync wrap paths once `processModule`
-  // succeeds: free the specifier entry early, and remember CJS modules so their
-  // transitive require() chain bypasses iitm (see `load`). Returns the wrapper
-  // module source.
-  function onWrapSuccess (realUrl, context, originalSpecifier, setters, originNamespaces) {
+  /**
+   * Finalizes a successful wrap and builds its module source.
+   *
+   * @param {string} realUrl The URL of the wrapped module.
+   * @param {LoadContext} context Its loader context.
+   * @param {string} originalSpecifier The original import specifier.
+   * @param {string[] | Map<string, string | StarBinding>} bindings Its exported bindings.
+   */
+  function onWrapSuccess (realUrl, context, originalSpecifier, bindings) {
     specifiers.delete(realUrl)
     // context.format is set to 'commonjs' by getCjsExports during processModule.
     if (context.format === 'commonjs') {
       cjsInIitmChain.add(realUrl)
     }
-    return buildWrapperSource(realUrl, setters, originalSpecifier, originNamespaces)
+    return buildWrapperSource(realUrl, bindings, originalSpecifier)
   }
 
   // Bookkeeping shared by the async and sync wrap paths when `processModule`
@@ -699,6 +695,10 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
   // (it just can't be Hook'ed) rather than taking down the whole app. We free
   // the specifier entry to avoid a leak, and log because a failure here is
   // usually an iitm bug and would otherwise be very tricky to debug.
+  /**
+   * @param {string} realUrl The URL whose wrapper could not be built.
+   * @param {unknown} cause The parse or wrapper-generation failure.
+   */
   function onWrapFailure (realUrl, cause) {
     specifiers.delete(realUrl)
     const err = new Error(`'import-in-the-middle' failed to wrap '${realUrl}'`)
@@ -728,11 +728,11 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
       }
 
       try {
-        const { setters, originNamespaces } = await driveAsync(
+        const { bindings } = await driveAsync(
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: parentGetSource }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, setters, originNamespaces) }
+        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         // Revert back to the non-iitm URL
@@ -768,11 +768,11 @@ register(${JSON.stringify(realUrl)}, __binder.namespace, __binder.set, __binder.
       }
 
       try {
-        const { setters, originNamespaces } = driveSync(
+        const { bindings } = driveSync(
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: nextLoad }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, setters, originNamespaces) }
+        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         url = realUrl

--- a/lib/get-esm-exports.mjs
+++ b/lib/get-esm-exports.mjs
@@ -3,6 +3,13 @@
 import { parse } from 'es-module-lexer'
 
 /**
+ * @typedef {object} LexedExports
+ * @property {string[] | Set<string>} exportNames
+ * @property {Array<{ specifier: string, parentURL: string }> | undefined} starReexports
+ * @property {boolean} hasModuleSyntax
+ */
+
+/**
  * Decodes an exported identifier the way the JS engine would. es-module-lexer
  * leaves Unicode escapes in bare identifier exports (`export const \u0061 = 1`)
  * as their raw spelling, while the module namespace exposes the cooked name
@@ -28,13 +35,8 @@ function decodeExportName (name) {
 
 /**
  * Lexes ESM source code with es-module-lexer and builds a list of exported
- * identifiers. In the baseline case the list is the simple identifier names as
- * written in the source. There is one special case:
- *
- * When an `export * from './foo.js'` line is encountered it is rewritten as
- * `* from ./foo.js`. This lets the interpreting code recognize a transitive
- * export and recursively parse the indicated module. The returned identifier
- * list will have "* from ./foo.js" as an item.
+ * identifiers. Bare star re-exports retain the legacy `* from <specifier>`
+ * representation expected by callers of this compatibility entry point.
  *
  * @param {string} moduleSource The source code of the module to lex.
  * @returns {Set<string>} The identifiers exported by the module along with any
@@ -55,21 +57,33 @@ export default function getEsmExports (moduleSource) {
  * does not.
  *
  * @param {string} moduleSource The source code of the module to lex.
- * @returns {{ exportNames: Set<string>, hasModuleSyntax: boolean }}
+ * @param {string} [parentURL] The URL of the module declaring star re-exports.
+ * @returns {LexedExports}
  */
-export function lexEsm (moduleSource) {
-  const exportNames = new Set()
+export function lexEsm (moduleSource, parentURL) {
+  const legacy = parentURL === undefined
+  const exportNames = legacy ? new Set() : []
+  let starReexports
   const [, exports, , hasModuleSyntax] = parse(moduleSource)
 
   for (const exported of exports) {
     if (exported.typeOnly) continue
 
     if (exported.type === 'reexport-all') {
-      exportNames.add(`* from ${exported.from}`)
+      if (legacy) {
+        exportNames.add(`* from ${exported.from}`)
+      } else {
+        (starReexports ??= []).push({ specifier: exported.from, parentURL })
+      }
     } else {
-      exportNames.add(decodeExportName(exported.name))
+      const name = decodeExportName(exported.name)
+      if (legacy) {
+        exportNames.add(name)
+      } else {
+        exportNames.push(name)
+      }
     }
   }
 
-  return { exportNames, hasModuleSyntax }
+  return { exportNames, starReexports, hasModuleSyntax }
 }

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -62,7 +62,7 @@ function getExportsForNodeBuiltIn (name) {
 
   if (!exports) {
     // get all properties both enumerable and non-enumerable
-    exports = new Set(addDefault(Object.getOwnPropertyNames(loadBuiltin(name))))
+    exports = addDefault(Object.getOwnPropertyNames(loadBuiltin(name)))
     // added in node 23 as alias for default in cjs modules
     if (hasModuleExportsCJSDefault) {
       exports.add('module.exports')
@@ -213,7 +213,7 @@ function * getCjsExports (url, context, source) {
     }
 
     // added in node 23 as alias for default in cjs modules
-    if (full.has('default') && hasModuleExportsCJSDefault) {
+    if (hasModuleExportsCJSDefault) {
       full.add('module.exports')
     }
 

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -28,8 +28,11 @@ function ensureParserInitialized () {
   }
 }
 
-function addDefault (arr) {
-  return new Set(['default', ...arr])
+/** @param {string[]} exportNames The detected CommonJS exports. */
+function addDefault (exportNames) {
+  const result = new Set(['default'])
+  for (const name of exportNames) result.add(name)
+  return result
 }
 
 // Cached exports for Node built-in modules

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -11,6 +11,9 @@ import { LOAD } from './io.mjs'
 const nodeMajor = Number(process.versions.node.split('.')[0])
 export const hasModuleExportsCJSDefault = nodeMajor >= 23
 
+/** @typedef {{ specifier: string, parentURL: string }} StarReexport */
+/** @typedef {{ exportNames: Iterable<string>, starReexports?: StarReexport[] }} ModuleExports */
+
 let parserInitialized = false
 let stripTypeScriptTypes
 
@@ -69,10 +72,10 @@ function getExportsForNodeBuiltIn (name) {
 
 const urlsBeingProcessed = new Set() // Guard against circular imports.
 
-// Memoizes an ESM module's export names by URL. A leaf reached from several
-// barrels (`export *`) would otherwise be read and lexed once per barrel, and
-// the same URL reached from separate top-level wraps would be lexed once per
-// wrap; the first lex serves every later one.
+// Memoizes an ESM module's export names and stars by URL. A leaf reached from
+// several barrels (`export *`) would otherwise be read and lexed once per
+// barrel; the same URL reached from separate top-level wraps would be lexed once
+// per wrap. The first lex serves every later one.
 //
 // This assumes a module's export names are stable for the process: the memo
 // serves a later, independent scan without re-running the loader chain's
@@ -143,9 +146,15 @@ function resolvePackageImports (specifier, fromUrl) {
   return null
 }
 
+/**
+ * @param {string} url The CommonJS module URL.
+ * @param {object} context The loader context.
+ * @param {string} source The module source.
+ * @returns {Generator<Array, ModuleExports>}
+ */
 function * getCjsExports (url, context, source) {
   if (urlsBeingProcessed.has(url)) {
-    return new Set()
+    return { exportNames: new Set() }
   }
   urlsBeingProcessed.add(url)
 
@@ -153,6 +162,7 @@ function * getCjsExports (url, context, source) {
     ensureParserInitialized()
     const result = parseCjs(source)
     const full = addDefault(result.exports)
+    let starReexports
 
     for (const reexport of result.reexports) {
       if (reexport.startsWith('node:') || builtinModules.includes(reexport)) {
@@ -187,8 +197,15 @@ function * getCjsExports (url, context, source) {
         continue
       }
 
-      for (const each of yield * getExports(newUrl, context)) {
+      const child = yield * getExports(newUrl, context)
+      for (const each of child.exportNames) {
         full.add(each)
+      }
+      if (child.starReexports !== undefined) {
+        starReexports ??= []
+        for (const starReexport of child.starReexports) {
+          starReexports.push(starReexport)
+        }
       }
     }
 
@@ -199,7 +216,7 @@ function * getCjsExports (url, context, source) {
 
     // we know that it's commonjs at this point, because ESM failed
     context.format = 'commonjs'
-    return full
+    return { exportNames: full, starReexports }
   } finally {
     urlsBeingProcessed.delete(url)
   }
@@ -220,15 +237,14 @@ function * getCjsExports (url, context, source) {
  * @param {object} context Context object as provided by the `load` hook from
  * the loaders API.
  *
- * @returns {Generator<Array, Set<string>>} A generator that yields I/O
- * operations and ultimately returns the identifiers exported by the module.
- * Please see {@link getEsmExports} for caveats on special identifiers that may
- * be included in the result set.
+ * @returns {Generator<Array, ModuleExports>} A generator that yields I/O
+ * operations and ultimately returns the identifiers and star re-exports of the
+ * module.
  */
 export function * getExports (url, context) {
   const cached = esmExportsCache.get(url)
   if (cached !== undefined) {
-    return cached.exportNames
+    return cached
   }
 
   // `[LOAD, ...]` gives us the possibility of getting the source from an
@@ -257,7 +273,7 @@ export function * getExports (url, context) {
     if (format === 'builtin') {
       // Builtins don't give us the source property, so we're stuck
       // just requiring it to get the exports.
-      return getExportsForNodeBuiltIn(url)
+      return { exportNames: getExportsForNodeBuiltIn(url) }
     }
 
     // Sometimes source is retrieved by parentLoad, CommonJs isn't.
@@ -280,22 +296,23 @@ export function * getExports (url, context) {
       return yield * getCjsExports(url, context, source)
     }
 
-    const { exportNames, hasModuleSyntax } = lexEsm(source)
+    const { exportNames, starReexports, hasModuleSyntax } = lexEsm(source, url)
+    const moduleExports = starReexports === undefined ? { exportNames } : { exportNames, starReexports }
 
     if (moduleFormat === 'module') {
-      esmExportsCache.set(url, { exportNames })
-      return exportNames
+      esmExportsCache.set(url, moduleExports)
+      return moduleExports
     }
 
     // At this point our `format` is either undefined or not known by us. When
     // there are no exports and no ESM syntax, fall back to CommonJS detection.
     // Strong evidence of ESM (static import/import.meta) keeps the empty ESM
     // export set rather than incorrectly treating the module as CJS.
-    if (!exportNames.size && !hasModuleSyntax) {
+    if (exportNames.length === 0 && !hasModuleSyntax) {
       return yield * getCjsExports(url, context, source)
     }
-    esmExportsCache.set(url, { exportNames })
-    return exportNames
+    esmExportsCache.set(url, moduleExports)
+    return moduleExports
   } catch (cause) {
     const err = new Error(`Failed to parse '${url}'`)
     err.cause = cause

--- a/lib/register.js
+++ b/lib/register.js
@@ -3,53 +3,53 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
 const importHooks = [] // TODO should this be a Set?
-const setters = new WeakMap()
-const getters = new WeakMap()
+const binders = new WeakMap()
 const specifiers = new Map()
 const toHook = []
 
-const proxyHandler = {
-  set (target, name, value) {
-    const set = setters.get(target)
-    const setter = set && set[name]
-    if (typeof setter === 'function') {
-      return setter(value)
-    }
-    // If a module doesn't export the property being assigned (e.g. no default
-    // export), there is no setter to call. Don't crash userland code.
-    return true
-  },
-
-  get (target, name) {
-    if (name === Symbol.toStringTag) {
-      return 'Module'
-    }
-
-    const getter = getters.get(target)[name]
-
-    if (typeof getter === 'function') {
-      return getter()
-    }
-  },
-
-  defineProperty (target, property, descriptor) {
-    if ((!('value' in descriptor))) {
-      throw new Error('Getters/setters are not supported for exports property descriptors.')
-    }
-
-    const set = setters.get(target)
-    const setter = set && set[property]
-    if (typeof setter === 'function') {
-      return setter(descriptor.value)
-    }
-    return true
+/**
+ * @param {object} source The module namespace.
+ * @param {string | symbol} name The export name.
+ */
+function readExport (source, name) {
+  if (name === 'module.exports' && !Object.hasOwn(source, name)) {
+    return source.default
   }
+  return source[name]
 }
 
-function register (name, namespace, set, get, specifier) {
+/**
+ * @param {object} target The proxy target.
+ * @param {string | symbol} name The export name.
+ * @param {unknown} value The replacement value.
+ */
+function setExport (target, name, value) {
+  return binders.get(target).write(name, value)
+}
+
+/**
+ * @param {object} target The proxy target.
+ * @param {string | symbol} name The export name.
+ * @param {PropertyDescriptor} descriptor The replacement descriptor.
+ */
+function defineExport (target, name, descriptor) {
+  if (!('value' in descriptor)) {
+    throw new Error('Getters/setters are not supported for exports property descriptors.')
+  }
+  return setExport(target, name, descriptor.value)
+}
+
+const proxyHandler = { defineProperty: defineExport, set: setExport }
+
+/**
+ * @param {string} name The wrapped module URL.
+ * @param {ModuleBinder} binder The wrapper's binding state.
+ * @param {string} specifier The original import specifier.
+ */
+function register (name, binder, specifier) {
+  const { namespace } = binder
   specifiers.set(name, specifier)
-  setters.set(namespace, set)
-  getters.set(namespace, get)
+  binders.set(namespace, binder)
   const proxy = new Proxy(namespace, proxyHandler)
   importHooks.forEach(hook => hook(name, proxy, specifier))
   toHook.push([name, proxy, specifier])
@@ -63,22 +63,36 @@ const RETRY_DELAYS = [0, 10, 50]
 
 /**
  * Per-wrapped-module state a generated wrapper builds once to expose its exports
- * through iitm's proxy. Each wrapper holds a local binding per export plus
- * `write`/`read` closures over it; `bind` seeds that binding from the real
- * module and installs the proxy's `set`/`get` for the name, and `flush` resolves
- * any export that was undefined (circular import) once it becomes available.
+ * through iitm's proxy. Each wrapper supplies one indexed writer for all local
+ * bindings; the constructor seeds them from the real module, and `flush`
+ * resolves any export that was undefined (circular import) once it becomes available.
  *
  * This is the boilerplate the wrapper used to inline in full per module. Hoisting
- * it here compiles it once instead of once per wrapped module and keeps the
- * per-export bind call site monomorphic.
+ * it here compiles the retry and proxy bookkeeping once instead of once per
+ * wrapped module.
  */
 class ModuleBinder {
   // Mimics a Module namespace object (https://tc39.es/ecma262/#sec-module-namespace-objects).
   namespace = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })
-  set = {}
-  get = {}
-  #overridden = Object.create(null)
-  #pending = []
+  #set = Object.create(null)
+  #write
+  #overridden
+  #pending
+
+  /**
+   * @param {object} source The wrapped module namespace.
+   * @param {string[]} [keys] Export names in wrapper-binding order.
+   * @param {(index: number, value: unknown) => void} [write] Assigns a wrapper binding by index.
+   * @param {object[]} [sources] Alternate namespaces for star-collision bindings.
+   */
+  constructor (source, keys, write, sources) {
+    this.#write = write
+    if (keys !== undefined) {
+      for (let index = 0; index < keys.length; index++) {
+        this.#bind(keys[index], index, sources?.[index] ?? source)
+      }
+    }
+  }
 
   /**
    * Seeds `key` from `source` and installs its proxy accessors. A value that is
@@ -86,51 +100,56 @@ class ModuleBinder {
    * import) is deferred to `flush`; any other throw propagates.
    *
    * @param {string} key The export name.
-   * @param {object} source The real module namespace to read the value from.
-   * @param {(value: unknown) => void} write Assigns the wrapper's local binding.
-   * @param {() => unknown} read Reads the wrapper's local binding.
-   * @param {boolean} useFallback Fall back to `source.default` (the synthetic
-   * `module.exports` name a builtin does not expose on its ESM namespace).
+   * @param {number} index The wrapper binding index.
+   * @param {object} source The binding's source namespace.
    * @returns {void}
    */
-  bind (key, source, write, read, useFallback) {
-    const readSource = useFallback
-      ? () => source[key] ?? source.default
-      : () => source[key]
-    this.#overridden[key] = false
-    let deferred = false
+  #bind (key, index, source) {
+    let value
     try {
-      const value = readSource()
-      write(value)
+      value = readExport(source, key)
+      this.#write(index, value)
       this.namespace[key] = value
     } catch (error) {
       if (!(error instanceof ReferenceError)) throw error
-      deferred = true
     }
-    if (deferred || read() === undefined) {
-      this.#pending.push(this.#makeUpdater(key, readSource, write))
+    if (value === undefined) {
+      (this.#pending ??= []).push(this.#makeUpdater(key, index, source))
     }
-    this.set[key] = (value) => {
-      this.#overridden[key] = true
-      write(value)
-      return true
+    this.#set[key] = index
+  }
+
+  /**
+   * @param {string | symbol} key The export name.
+   * @param {unknown} value The replacement value.
+   * @returns {boolean}
+   */
+  write (key, value) {
+    const index = this.#set[key]
+    if (index !== undefined) {
+      this.#write(index, value)
+      if (this.#pending !== undefined) {
+        this.#overridden ??= Object.create(null)
+        this.#overridden[key] = true
+      }
+      this.namespace[key] = value
     }
-    this.get[key] = read
+    return true
   }
 
   /**
    * @param {string} key The export name to update.
-   * @param {() => unknown} readSource Reads the current value from the real module.
-   * @param {(value: unknown) => void} write Assigns the wrapper's local binding.
+   * @param {number} index The wrapper binding index.
+   * @param {object} source The real module namespace.
    * @returns {() => boolean} Updater returning whether the value is now settled.
    */
-  #makeUpdater (key, readSource, write) {
+  #makeUpdater (key, index, source) {
     return () => {
-      if (this.#overridden[key] === true) return true
+      if (this.#overridden?.[key] === true) return true
       try {
-        const value = readSource()
+        const value = readExport(source, key)
         if (value !== undefined) {
-          write(value)
+          this.#write(index, value)
           this.namespace[key] = value
           return true
         }
@@ -147,10 +166,13 @@ class ModuleBinder {
   }
 
   #flushOnce () {
-    const next = []
-    for (const updater of this.#pending) {
+    const pending = this.#pending
+    if (pending === undefined) return
+
+    let next
+    for (const updater of pending) {
       // If it still throws ReferenceError, keep it for the (single) next attempt.
-      if (updater() !== true) next.push(updater)
+      if (updater() !== true) (next ??= []).push(updater)
     }
     this.#pending = next
   }
@@ -163,7 +185,7 @@ class ModuleBinder {
    * @returns {void}
    */
   flush () {
-    if (this.#pending.length === 0) return
+    if (this.#pending === undefined) return
     queueMicrotask(() => {
       this.#flushOnce()
       this.#scheduleRetry(0)
@@ -175,10 +197,10 @@ class ModuleBinder {
    * @returns {void}
    */
   #scheduleRetry (attempt) {
-    if (this.#pending.length === 0) return
+    if (this.#pending === undefined) return
     if (attempt >= RETRY_DELAYS.length) {
       // Give up: leave exports as-is to avoid unbounded retries.
-      this.#pending = []
+      this.#pending = undefined
       return
     }
     const timer = setTimeout(() => {

--- a/test/fixtures/cjs-reexport-esm-star.js
+++ b/test/fixtures/cjs-reexport-esm-star.js
@@ -1,0 +1,1 @@
+module.exports = require('./reexport-nested-top.mjs')

--- a/test/fixtures/export-name-collision.mjs
+++ b/test/fixtures/export-name-collision.mjs
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+const dashed = 'dashed'
+const proto = 'proto'
+const underscored = 'underscored'
+
+export { dashed as 'a-b', proto as '__proto__', underscored as 'a_b' }

--- a/test/fixtures/module-exports-cjs-star.mjs
+++ b/test/fixtures/module-exports-cjs-star.mjs
@@ -1,0 +1,1 @@
+export * from './something.js'

--- a/test/fixtures/module-exports-null-star.mjs
+++ b/test/fixtures/module-exports-null-star.mjs
@@ -1,0 +1,1 @@
+export * from './module-exports-null.mjs'

--- a/test/fixtures/module-exports-null.mjs
+++ b/test/fixtures/module-exports-null.mjs
@@ -1,0 +1,4 @@
+export default 'fallback'
+
+const value = null
+export { value as 'module.exports' }

--- a/test/fixtures/module-exports-star.mjs
+++ b/test/fixtures/module-exports-star.mjs
@@ -1,0 +1,1 @@
+export * from './module-exports-cjs-shim.mjs'

--- a/test/fixtures/module-exports-undefined-star.mjs
+++ b/test/fixtures/module-exports-undefined-star.mjs
@@ -1,0 +1,1 @@
+export * from './module-exports-undefined.mjs'

--- a/test/fixtures/module-exports-undefined.mjs
+++ b/test/fixtures/module-exports-undefined.mjs
@@ -1,0 +1,4 @@
+export default 'fallback'
+
+const value = undefined
+export { value as 'module.exports' }

--- a/test/fixtures/reexport-ambiguous-repeated.mjs
+++ b/test/fixtures/reexport-ambiguous-repeated.mjs
@@ -1,0 +1,5 @@
+/* eslint-disable import/export -- repeated ambiguous stars are the behavior under test */
+
+export * from './duplicate-a.mjs'
+export * from './duplicate-b.mjs'
+export * from './duplicate-a.mjs'

--- a/test/fixtures/reexport-ambiguous-third.mjs
+++ b/test/fixtures/reexport-ambiguous-third.mjs
@@ -1,0 +1,5 @@
+/* eslint-disable import/export -- three ambiguous stars are the behavior under test */
+
+export * from './duplicate-a.mjs'
+export * from './duplicate-b.mjs'
+export * from './duplicate-c.mjs'

--- a/test/fixtures/reexport-nested-agg.mjs
+++ b/test/fixtures/reexport-nested-agg.mjs
@@ -3,3 +3,4 @@
 // while processing this module.
 export * from './reexport-nested-leaf.mjs'
 export * from './reexport-nested-mid.mjs'
+export default 'not-reexported'

--- a/test/fixtures/reexport-nested-mid.mjs
+++ b/test/fixtures/reexport-nested-mid.mjs
@@ -1,1 +1,2 @@
 export * from './reexport-nested-leaf.mjs'
+export const unique = 43

--- a/test/fixtures/reexport-repeated-same.mjs
+++ b/test/fixtures/reexport-repeated-same.mjs
@@ -1,0 +1,4 @@
+/* eslint-disable import/export -- duplicate star declarations are the behavior under test */
+
+export * from './duplicate-a.mjs'
+export * from './duplicate-a.mjs'

--- a/test/fixtures/star-builtin.mjs
+++ b/test/fixtures/star-builtin.mjs
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+// eslint-disable-next-line n/no-deprecated-api
+export * from 'node:events'

--- a/test/get-esm-exports/get-exports-builtin-non-enumerable.mjs
+++ b/test/get-esm-exports/get-exports-builtin-non-enumerable.mjs
@@ -24,26 +24,26 @@ const nonEnumerableNames = Object.getOwnPropertyNames(moduleValue)
 
 const io = { load: async () => ({ source: null, format: 'builtin' }) }
 
-const exports = await driveAsync(getExports(builtin, { format: 'builtin' }), io)
+const { exportNames } = await driveAsync(getExports(builtin, { format: 'builtin' }), io)
 
 // The whole point: non-enumerable own properties (e.g. `prototype`) that
 // Object.keys would miss must still be discovered.
 ok(nonEnumerableNames.length > 0, `precondition: ${builtin} has non-enumerable own properties`)
 for (const name of nonEnumerableNames) {
-  ok(exports.has(name), `non-enumerable ${name} should be in exports`)
+  ok(exportNames.has(name), `non-enumerable ${name} should be in exports`)
 }
 
 // Sanity check: an enumerable export should still be present.
-ok(exports.has('once'), 'enumerable export (once) should be in exports')
-ok(exports.has('default'), 'default should be in exports')
+ok(exportNames.has('once'), 'enumerable export (once) should be in exports')
+ok(exportNames.has('default'), 'default should be in exports')
 
 // Node >= 23 adds `module.exports` as an alias for the default export in CJS modules
 if (hasModuleExportsCJSDefault) {
-  ok(exports.has('module.exports'), 'module.exports should be in exports on Node >= 23')
+  ok(exportNames.has('module.exports'), 'module.exports should be in exports on Node >= 23')
 } else {
-  ok(!exports.has('module.exports'), 'module.exports should not be in exports on Node < 23')
+  ok(!exportNames.has('module.exports'), 'module.exports should not be in exports on Node < 23')
 }
 
-strictEqual(typeof exports.has, 'function', 'getExports should return a Set')
+strictEqual(typeof exportNames.has, 'function', 'builtin exportNames should be a Set')
 
 console.log('✅ getExports includes non-enumerable built-in module exports')

--- a/test/get-esm-exports/v20-get-esm-exports.mjs
+++ b/test/get-esm-exports/v20-get-esm-exports.mjs
@@ -1,6 +1,6 @@
 'use strict'
 
-import getEsmExports from '../../lib/get-esm-exports.mjs'
+import getEsmExports, { lexEsm } from '../../lib/get-esm-exports.mjs'
 import fs from 'fs'
 import assert from 'assert'
 import path from 'path'
@@ -27,6 +27,11 @@ assert.deepEqual(Array.from(getEsmExports('export type { Type } from "module-nam
 assert.deepEqual(Array.from(getEsmExports('export type * from "module-name"')), [])
 assert.deepEqual(Array.from(getEsmExports('export const alpha: number = 1, beta: string = "two"')), ['alpha', 'beta'])
 assert.deepEqual(Array.from(getEsmExports('const type = 1; export { type }')), ['type'])
+assert.deepEqual(lexEsm('export const direct = 1; export * from "dependency"', 'file:///parent.mjs'), {
+  exportNames: ['direct'],
+  starReexports: [{ specifier: 'dependency', parentURL: 'file:///parent.mjs' }],
+  hasModuleSyntax: true
+})
 
 // // Generate fixture data
 // fixture.split('\n').forEach(line => {

--- a/test/hook/reexport-same-source.mjs
+++ b/test/hook/reexport-same-source.mjs
@@ -3,6 +3,13 @@ import * as nested from '../fixtures/reexport-nested-top.mjs'
 import { strictEqual } from 'assert'
 import Hook from '../../index.js'
 
+let moduleExportsStarExports
+let moduleExportsCjsStarExports
+let moduleExportsNullStarExports
+let moduleExportsUndefinedStarExports
+let ambiguousRepeatedExports
+let ambiguousThirdExports
+
 // `val` reaches the entry module through two `export *` chains that both bottom
 // out at the same leaf module, so per ECMAScript ResolveExport it is one binding
 // that stays exported and keeps its value (issue #171). The previous dedup
@@ -22,17 +29,64 @@ Hook((exports, name) => {
     strictEqual('nested' in exports, true)
     strictEqual(exports.nested, 42)
   }
+  if (name.includes('duplicate-a.mjs')) {
+    exports.foo = 'hooked'
+  }
+  if (name.includes('module-exports-star.mjs')) {
+    moduleExportsStarExports = exports
+  }
+  if (name.includes('module-exports-cjs-star.mjs')) {
+    moduleExportsCjsStarExports = exports
+  }
+  if (name.includes('module-exports-null-star.mjs')) {
+    moduleExportsNullStarExports = exports
+  }
+  if (name.includes('module-exports-undefined-star.mjs')) {
+    moduleExportsUndefinedStarExports = exports
+  }
+  if (name.includes('reexport-ambiguous-repeated.mjs')) {
+    ambiguousRepeatedExports = exports
+  }
+  if (name.includes('reexport-ambiguous-third.mjs')) {
+    ambiguousThirdExports = exports
+  }
 })
 
 strictEqual('val' in lib, true)
 strictEqual(lib.val, 1)
 strictEqual('nested' in nested, true)
 strictEqual(nested.nested, 42)
+strictEqual(nested.unique, 43)
+strictEqual('default' in nested, false)
 
 const ambiguous = await import('../fixtures/duplicate.mjs')
 const explicit = await import('../fixtures/duplicate-explicit.mjs')
 const override = await import('../fixtures/reexport-explicit-override.mjs')
+const repeated = await import('../fixtures/reexport-repeated-same.mjs')
+const ambiguousRepeated = await import('../fixtures/reexport-ambiguous-repeated.mjs')
+const ambiguousThird = await import('../fixtures/reexport-ambiguous-third.mjs')
+const moduleExportsStar = await import('../fixtures/module-exports-star.mjs')
+const moduleExportsCjsStar = await import('../fixtures/module-exports-cjs-star.mjs')
+const moduleExportsNullStar = await import('../fixtures/module-exports-null-star.mjs')
+const moduleExportsUndefinedStar = await import('../fixtures/module-exports-undefined-star.mjs')
 
 strictEqual('foo' in ambiguous, false)
 strictEqual(explicit.foo, 'c')
 strictEqual(override.foo, 'c')
+strictEqual('foo' in ambiguousRepeated, false)
+strictEqual('foo' in ambiguousRepeatedExports, false)
+strictEqual('foo' in ambiguousThird, false)
+strictEqual('foo' in ambiguousThirdExports, false)
+strictEqual(typeof moduleExportsStar['module.exports'], 'function')
+strictEqual(typeof moduleExportsStarExports['module.exports'], 'function')
+strictEqual(moduleExportsNullStar['module.exports'], null)
+strictEqual(moduleExportsNullStarExports['module.exports'], null)
+strictEqual('module.exports' in moduleExportsUndefinedStar, true)
+strictEqual(moduleExportsUndefinedStar['module.exports'], undefined)
+strictEqual('module.exports' in moduleExportsUndefinedStarExports, true)
+strictEqual(moduleExportsUndefinedStarExports['module.exports'], undefined)
+if (parseInt(process.versions.node, 10) >= 23) {
+  strictEqual(typeof moduleExportsCjsStar['module.exports'], 'function')
+  strictEqual(typeof moduleExportsCjsStarExports['module.exports'], 'function')
+}
+strictEqual(repeated.foo, 'hooked')

--- a/test/hook/v24-cjs-reexport-esm-star.mjs
+++ b/test/hook/v24-cjs-reexport-esm-star.mjs
@@ -2,9 +2,21 @@ import { strictEqual } from 'assert'
 
 import Hook from '../../index.js'
 
-const hook = new Hook(() => {})
+/** @type {Record<string, unknown> | undefined} */
+let hookedExports
+
+/**
+ * @param {Record<string, unknown>} exports The intercepted module exports.
+ * @param {string} name The intercepted module name.
+ */
+function captureExports (exports, name) {
+  if (name.includes('cjs-reexport-esm-star.js')) hookedExports = exports
+}
+
+const hook = new Hook(captureExports)
 const module = await import('../fixtures/cjs-reexport-esm-star.js')
 
 strictEqual(module.nested, 42)
+strictEqual(hookedExports?.nested, 42)
 
 hook.unhook()

--- a/test/hook/v24-cjs-reexport-esm-star.mjs
+++ b/test/hook/v24-cjs-reexport-esm-star.mjs
@@ -1,0 +1,10 @@
+import { strictEqual } from 'assert'
+
+import Hook from '../../index.js'
+
+const hook = new Hook(() => {})
+const module = await import('../fixtures/cjs-reexport-esm-star.js')
+
+strictEqual(module.nested, 42)
+
+hook.unhook()

--- a/test/low-level/module-binder.mjs
+++ b/test/low-level/module-binder.mjs
@@ -27,6 +27,25 @@ function makeBinder (source, key = 'foo', sources) {
   return { binder: new ModuleBinder(source, [key], write, sources), slot }
 }
 
+/**
+ * @returns {{ callbacks: Array<() => void>, restore: () => void }}
+ */
+function interceptTimeouts () {
+  const callbacks = []
+  const originalSetTimeout = globalThis.setTimeout
+  /** @param {() => void} callback */
+  globalThis.setTimeout = (callback) => {
+    callbacks.push(callback)
+    return { unref () {} }
+  }
+  return {
+    callbacks,
+    restore () {
+      globalThis.setTimeout = originalSetTimeout
+    }
+  }
+}
+
 // Construction seeds the current source value into the export and module object.
 {
   const source = { foo: 42 }
@@ -88,21 +107,26 @@ function makeBinder (source, key = 'foo', sources) {
 // A source still in its dead zone on the retry read keeps the updater pending
 // (ReferenceError from the retried read is swallowed), then resolves.
 {
-  let stage = 0
-  const source = {
-    get foo () {
-      // Throw at bind time and on the first flush; resolve afterwards.
-      if (stage++ < 2) throw new ReferenceError('tdz')
-      return 11
+  const { callbacks, restore } = interceptTimeouts()
+  try {
+    let stage = 0
+    const source = {
+      get foo () {
+        // Throw at bind time and on the first flush; resolve afterwards.
+        if (stage++ < 2) throw new ReferenceError('tdz')
+        return 11
+      }
     }
+    const { binder, slot } = makeBinder(source)
+    strictEqual(slot.value, undefined, 'still deferred after bind')
+    binder.flush()
+    await Promise.resolve()
+    strictEqual(slot.value, undefined, 'still deferred after first flush attempt')
+    callbacks.shift()()
+    strictEqual(slot.value, 11, 'resolved on a later retry once live')
+  } finally {
+    restore()
   }
-  const { binder, slot } = makeBinder(source)
-  strictEqual(slot.value, undefined, 'still deferred after bind')
-  binder.flush()
-  await Promise.resolve()
-  strictEqual(slot.value, undefined, 'still deferred after first flush attempt')
-  await new Promise((resolve) => setTimeout(resolve, 20))
-  strictEqual(slot.value, 11, 'resolved on a later retry once live')
 }
 
 // A non-ReferenceError thrown while seeding at bind time propagates.
@@ -124,13 +148,7 @@ function makeBinder (source, key = 'foo', sources) {
 // Exhausting every retry releases the pending updater and later flushes stay
 // inactive, even if the source eventually gets a value.
 {
-  const callbacks = []
-  const originalSetTimeout = globalThis.setTimeout
-  /** @param {() => void} callback */
-  globalThis.setTimeout = (callback) => {
-    callbacks.push(callback)
-    return { unref () {} }
-  }
+  const { callbacks, restore } = interceptTimeouts()
   try {
     const source = {}
     const { binder, slot } = makeBinder(source)
@@ -143,6 +161,6 @@ function makeBinder (source, key = 'foo', sources) {
     await Promise.resolve()
     strictEqual(slot.value, undefined, 'exhausted updater is not retried')
   } finally {
-    globalThis.setTimeout = originalSetTimeout
+    restore()
   }
 }

--- a/test/low-level/module-binder.mjs
+++ b/test/low-level/module-binder.mjs
@@ -1,43 +1,45 @@
 // Unit-tests the ModuleBinder that generated wrappers use. The wrapper boilerplate
-// (seed export value, expose set/get, defer TDZ reads) lives here as real code
+// (seed export values, apply hook writes, defer TDZ reads) lives here as real code
 // rather than emitted per wrapper, so it is exercised directly instead of only
 // through the full loader.
 
 import { createRequire } from 'module'
-import { strictEqual, deepStrictEqual, throws } from 'assert'
+import { strictEqual, throws } from 'assert'
 
 const require = createRequire(import.meta.url)
 const { ModuleBinder } = require('../../lib/register.js')
 
-// A wrapper models each export as a local binding plus write/read closures over
-// it; mimic one here.
-function makeSlot (initial) {
-  const slot = { value: initial }
-  return {
-    slot,
-    write: (value) => { slot.value = value },
-    read: () => slot.value
+/**
+ * @param {object} source The wrapped module namespace.
+ * @param {string} [key] Its export name.
+ * @param {object[]} [sources] Alternate namespaces in wrapper-binding order.
+ */
+function makeBinder (source, key = 'foo', sources) {
+  const slot = { value: undefined }
+  /**
+   * @param {number} index The wrapper binding index.
+   * @param {unknown} value The export value.
+   */
+  function write (index, value) {
+    strictEqual(index, 0)
+    slot.value = value
   }
+  return { binder: new ModuleBinder(source, [key], write, sources), slot }
 }
 
-// bind seeds the current source value into the export and the module object.
+// Construction seeds the current source value into the export and module object.
 {
-  const binder = new ModuleBinder()
   const source = { foo: 42 }
-  const { slot, write, read } = makeSlot(undefined)
-  binder.bind('foo', source, write, read, false)
-  strictEqual(slot.value, 42, 'bind seeds the export binding')
-  strictEqual(binder.namespace.foo, 42, 'bind seeds the module object')
-  strictEqual(binder.get.foo(), 42, 'get returns the current value')
+  const { binder, slot } = makeBinder(source)
+  strictEqual(slot.value, 42, 'construction seeds the export binding')
+  strictEqual(binder.namespace.foo, 42, 'construction seeds the module object')
 }
 
 // A hook writing through set overrides the value and wins over later updates.
 {
-  const binder = new ModuleBinder()
   const source = { foo: 42 }
-  const { slot, write, read } = makeSlot(undefined)
-  binder.bind('foo', source, write, read, false)
-  strictEqual(binder.set.foo(99), true, 'set returns true')
+  const { binder, slot } = makeBinder(source)
+  strictEqual(binder.write('foo', 99), true, 'write returns true')
   strictEqual(slot.value, 99, 'set overrides the export binding')
   binder.flush()
   strictEqual(slot.value, 99, 'flush does not clobber an overridden value')
@@ -45,20 +47,16 @@ function makeSlot (initial) {
 
 // useFallback reads source.default when the named export is missing.
 {
-  const binder = new ModuleBinder()
   const source = { default: 7 }
-  const { slot, write, read } = makeSlot(undefined)
-  binder.bind('module.exports', source, write, read, true)
-  strictEqual(slot.value, 7, 'useFallback falls back to source.default')
+  const { slot } = makeBinder(source, 'module.exports')
+  strictEqual(slot.value, 7, 'module.exports falls back to source.default')
 }
 
 // A value that is undefined at bind time is retried on the microtask once the
 // source provides it (the circular-import / TDZ path).
 {
-  const binder = new ModuleBinder()
   const source = {}
-  const { slot, write, read } = makeSlot(undefined)
-  binder.bind('foo', source, write, read, false)
+  const { binder, slot } = makeBinder(source)
   strictEqual(slot.value, undefined, 'no value yet')
   source.foo = 5
   binder.flush()
@@ -68,11 +66,9 @@ function makeSlot (initial) {
 
 // A ReferenceError from the source read (TDZ) defers rather than throwing.
 {
-  const binder = new ModuleBinder()
   let live = false
   const source = { get foo () { if (!live) throw new ReferenceError('tdz'); return 8 } }
-  const { slot, write, read } = makeSlot(undefined)
-  binder.bind('foo', source, write, read, false)
+  const { binder, slot } = makeBinder(source)
   strictEqual(slot.value, undefined, 'TDZ read deferred, no throw')
   live = true
   binder.flush()
@@ -80,20 +76,18 @@ function makeSlot (initial) {
   strictEqual(slot.value, 8, 'deferred TDZ value resolved after it became live')
 }
 
-// Two binders keep independent state (set/get/namespace are per instance).
+// Two binders keep independent state.
 {
-  const a = new ModuleBinder()
-  const b = new ModuleBinder()
-  a.bind('foo', { foo: 1 }, () => {}, () => 1, false)
-  b.bind('bar', { bar: 2 }, () => {}, () => 2, false)
-  deepStrictEqual(Object.keys(a.set), ['foo'])
-  deepStrictEqual(Object.keys(b.set), ['bar'])
+  const { binder: a } = makeBinder({ foo: 1 })
+  const { binder: b } = makeBinder({ bar: 2 }, 'bar')
+  a.write('foo', 3)
+  strictEqual(a.namespace.foo, 3)
+  strictEqual(b.namespace.bar, 2)
 }
 
 // A source still in its dead zone on the retry read keeps the updater pending
 // (ReferenceError from the retried read is swallowed), then resolves.
 {
-  const binder = new ModuleBinder()
   let stage = 0
   const source = {
     get foo () {
@@ -102,8 +96,7 @@ function makeSlot (initial) {
       return 11
     }
   }
-  const { slot, write, read } = makeSlot(undefined)
-  binder.bind('foo', source, write, read, false)
+  const { binder, slot } = makeBinder(source)
   strictEqual(slot.value, undefined, 'still deferred after bind')
   binder.flush()
   await Promise.resolve()
@@ -114,8 +107,42 @@ function makeSlot (initial) {
 
 // A non-ReferenceError thrown while seeding at bind time propagates.
 {
-  const binder = new ModuleBinder()
   const source = { get foo () { throw new TypeError('boom') } }
-  const { write, read } = makeSlot(undefined)
-  throws(() => binder.bind('foo', source, write, read, false), TypeError)
+  throws(() => makeBinder(source), TypeError)
+}
+
+{
+  const source = {}
+  const { binder, slot } = makeBinder(source)
+  source.foo = 13
+  binder.flush()
+  binder.flush()
+  await Promise.resolve()
+  strictEqual(slot.value, 13, 'concurrent flushes share a resolved pending queue')
+}
+
+// Exhausting every retry releases the pending updater and later flushes stay
+// inactive, even if the source eventually gets a value.
+{
+  const callbacks = []
+  const originalSetTimeout = globalThis.setTimeout
+  /** @param {() => void} callback */
+  globalThis.setTimeout = (callback) => {
+    callbacks.push(callback)
+    return { unref () {} }
+  }
+  try {
+    const source = {}
+    const { binder, slot } = makeBinder(source)
+    binder.flush()
+    await Promise.resolve()
+    while (callbacks.length > 0) callbacks.shift()()
+
+    source.foo = 13
+    binder.flush()
+    await Promise.resolve()
+    strictEqual(slot.value, undefined, 'exhausted updater is not retried')
+  } finally {
+    globalThis.setTimeout = originalSetTimeout
+  }
 }

--- a/test/register/v22.15-sync-reexport-same-source.mjs
+++ b/test/register/v22.15-sync-reexport-same-source.mjs
@@ -11,6 +11,12 @@ register()
 
 let sawSameSource = false
 let sawNested = false
+let moduleExportsStarExports
+let moduleExportsCjsStarExports
+let moduleExportsNullStarExports
+let moduleExportsUndefinedStarExports
+let ambiguousRepeatedExports
+let ambiguousThirdExports
 
 // eslint-disable-next-line no-new
 new Hook((exports, name) => {
@@ -22,12 +28,60 @@ new Hook((exports, name) => {
     sawNested = true
     strictEqual(exports.nested, 42)
   }
+  if (typeof name === 'string' && name.includes('duplicate-a.mjs')) {
+    exports.foo = 'hooked'
+  }
+  if (typeof name === 'string' && name.includes('module-exports-star.mjs')) {
+    moduleExportsStarExports = exports
+  }
+  if (typeof name === 'string' && name.includes('module-exports-cjs-star.mjs')) {
+    moduleExportsCjsStarExports = exports
+  }
+  if (typeof name === 'string' && name.includes('module-exports-null-star.mjs')) {
+    moduleExportsNullStarExports = exports
+  }
+  if (typeof name === 'string' && name.includes('module-exports-undefined-star.mjs')) {
+    moduleExportsUndefinedStarExports = exports
+  }
+  if (typeof name === 'string' && name.includes('reexport-ambiguous-repeated.mjs')) {
+    ambiguousRepeatedExports = exports
+  }
+  if (typeof name === 'string' && name.includes('reexport-ambiguous-third.mjs')) {
+    ambiguousThirdExports = exports
+  }
 })
 
 const lib = await import('../fixtures/reexport-same-source.mjs')
 const nested = await import('../fixtures/reexport-nested-top.mjs')
+const repeated = await import('../fixtures/reexport-repeated-same.mjs')
+const ambiguousRepeated = await import('../fixtures/reexport-ambiguous-repeated.mjs')
+const ambiguousThird = await import('../fixtures/reexport-ambiguous-third.mjs')
+const moduleExportsStar = await import('../fixtures/module-exports-star.mjs')
+const moduleExportsCjsStar = await import('../fixtures/module-exports-cjs-star.mjs')
+const moduleExportsNullStar = await import('../fixtures/module-exports-null-star.mjs')
+const moduleExportsUndefinedStar = await import('../fixtures/module-exports-undefined-star.mjs')
 
 strictEqual(sawSameSource, true)
 strictEqual(lib.val, 1)
 strictEqual(sawNested, true)
 strictEqual(nested.nested, 42)
+strictEqual('foo' in ambiguousRepeated, false)
+strictEqual('foo' in ambiguousRepeatedExports, false)
+strictEqual('foo' in ambiguousThird, false)
+strictEqual('foo' in ambiguousThirdExports, false)
+strictEqual(typeof moduleExportsStar['module.exports'], 'function')
+strictEqual(typeof moduleExportsStarExports['module.exports'], 'function')
+strictEqual(moduleExportsNullStar['module.exports'], null)
+strictEqual(moduleExportsNullStarExports['module.exports'], null)
+strictEqual('module.exports' in moduleExportsUndefinedStar, true)
+strictEqual(moduleExportsUndefinedStar['module.exports'], undefined)
+strictEqual('module.exports' in moduleExportsUndefinedStarExports, true)
+strictEqual(moduleExportsUndefinedStarExports['module.exports'], undefined)
+if (parseInt(process.versions.node, 10) >= 23) {
+  strictEqual(typeof moduleExportsCjsStar['module.exports'], 'function')
+  strictEqual(typeof moduleExportsCjsStarExports['module.exports'], 'function')
+} else {
+  strictEqual('module.exports' in moduleExportsCjsStar, false)
+  strictEqual('module.exports' in moduleExportsCjsStarExports, false)
+}
+strictEqual(repeated.foo, 'hooked')

--- a/test/register/v22.15-sync-reexport-same-source.mjs
+++ b/test/register/v22.15-sync-reexport-same-source.mjs
@@ -17,6 +17,7 @@ let moduleExportsNullStarExports
 let moduleExportsUndefinedStarExports
 let ambiguousRepeatedExports
 let ambiguousThirdExports
+let cjsReexportEsmStarExports
 
 // eslint-disable-next-line no-new
 new Hook((exports, name) => {
@@ -49,6 +50,9 @@ new Hook((exports, name) => {
   if (typeof name === 'string' && name.includes('reexport-ambiguous-third.mjs')) {
     ambiguousThirdExports = exports
   }
+  if (typeof name === 'string' && name.includes('cjs-reexport-esm-star.js')) {
+    cjsReexportEsmStarExports = exports
+  }
 })
 
 const lib = await import('../fixtures/reexport-same-source.mjs')
@@ -60,6 +64,7 @@ const moduleExportsStar = await import('../fixtures/module-exports-star.mjs')
 const moduleExportsCjsStar = await import('../fixtures/module-exports-cjs-star.mjs')
 const moduleExportsNullStar = await import('../fixtures/module-exports-null-star.mjs')
 const moduleExportsUndefinedStar = await import('../fixtures/module-exports-undefined-star.mjs')
+const cjsReexportEsmStar = await import('../fixtures/cjs-reexport-esm-star.js')
 
 strictEqual(sawSameSource, true)
 strictEqual(lib.val, 1)
@@ -84,4 +89,6 @@ if (parseInt(process.versions.node, 10) >= 23) {
   strictEqual('module.exports' in moduleExportsCjsStar, false)
   strictEqual('module.exports' in moduleExportsCjsStarExports, false)
 }
+strictEqual(cjsReexportEsmStar.nested, 42)
+strictEqual(cjsReexportEsmStarExports?.nested, 42)
 strictEqual(repeated.foo, 'hooked')

--- a/test/register/v22.15-sync-register-hooks.mjs
+++ b/test/register/v22.15-sync-register-hooks.mjs
@@ -73,6 +73,8 @@ nodeModule.registerHooks({
 register()
 
 let somethingHooked = false
+let collisionHooked = false
+let starBuiltinExports
 let typescriptCjsExports
 let wrapFailureHooked = false
 
@@ -82,6 +84,15 @@ new Hook((exports, name) => {
   if (typeof name === 'string' && /something\.mjs/.test(name)) {
     somethingHooked = true
     exports.foo += 15
+  }
+  if (typeof name === 'string' && name.endsWith('/export-name-collision.mjs')) {
+    collisionHooked = true
+    exports['a-b'] = 'wrapped-dashed'
+    Reflect.set(exports, '__proto__', 'wrapped-proto')
+    exports.a_b = 'wrapped-underscored'
+  }
+  if (typeof name === 'string' && name.endsWith('/star-builtin.mjs')) {
+    starBuiltinExports = exports
   }
   if (typeof name === 'string' && name.endsWith('/typescript-cjs-hook.cts')) {
     typescriptCjsExports = exports
@@ -98,6 +109,16 @@ const namespace = await import('../fixtures/something.mjs')
 ok(somethingHooked, 'sync hook should have run for something.mjs')
 strictEqual(namespace.foo, 57, 'hook-mutated named export should be visible through the wrapper')
 strictEqual(typeof namespace.default, 'function', 'default export should be preserved')
+
+const collision = await import('../fixtures/export-name-collision.mjs')
+ok(collisionHooked, 'sync hook should run for colliding export names')
+strictEqual(collision['a-b'], 'wrapped-dashed', 'quoted export should keep an independent wrapper binding')
+strictEqual(Reflect.get(collision, '__proto__'), 'wrapped-proto', 'prototype-shaped export should keep its wrapper binding')
+strictEqual(collision.a_b, 'wrapped-underscored', 'identifier export should keep an independent wrapper binding')
+
+const starBuiltin = await import('../fixtures/star-builtin.mjs')
+strictEqual('module.exports' in starBuiltin, false, 'export star should exclude the builtin default alias')
+strictEqual('module.exports' in starBuiltinExports, false, 'hook proxy should exclude the builtin default alias')
 
 const typescriptCjs = await import('../fixtures/typescript-cjs-hook.cts')
 strictEqual(typescriptCjs.default.epsilon, 5)


### PR DESCRIPTION
String-based star setters forced the wrapper to build recursive namespace registries and eager deduplication state. Structured binding records allocate conflict state only when a second origin appears.

This also keeps repeated paths to one binding unambiguous and preserves explicit `null` or `undefined` `module.exports` values.

On Node 24.20.0 with V8 13.6.233.17-node.53, lazy target tracking took 9.31 to 9.38 ns/op in two fresh runs. Eager `Set` allocation took 27.97 to 30.12 ns/op on the same one-to-three-target workload.

The sync-hook suite found no reproducible end-to-end regression across small, large, TypeScript, star-reexport, and real dependency workloads.
