### PR TITLE
fix(esm): preserve circular re-export initialization

### DIFF
--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -36,12 +36,46 @@ const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
 /** @typedef {import('node:module').LoadHookContext} LoadContext */
 /** @typedef {import('node:module').LoadFnOutput} LoadResult */
 /** @typedef {string | { specifier: string, format: 'module-typescript' | 'commonjs-typescript' }} SpecifierData */
+/** @typedef {{ specifier: string, parentURL: string }} InitiatingImport */
 /** @typedef {{ name: string, origin: string }} StarBinding */
 /**
  * @typedef {object} ProcessResult
  * @property {string[] | Map<string, string | StarBinding>} bindings
  * @property {Map<string, string> | undefined} origins
+ * @property {Map<string, Map<string, string>> | undefined} [cyclicImports]
  */
+/**
+ * @typedef {object} CycleState
+ * @property {string} rootUrl
+ * @property {Map<string, Map<string, string>> | undefined} imports
+ */
+
+/** @typedef {Map<string, string | Set<string>>} CyclicImportTargets */
+
+/**
+ * @param {string} specifier The descendant module's static import specifier.
+ * @param {string} parentURL The descendant module URL.
+ * @param {CycleState} state The wrapper root and detected cycle edges.
+ */
+function addCyclicImport (specifier, parentURL, state) {
+  let targets = state.imports?.get(parentURL)
+  if (targets === undefined) {
+    state.imports ??= new Map()
+    targets = new Map()
+    state.imports.set(parentURL, targets)
+  }
+  targets.set(specifier, state.rootUrl)
+}
+
+/**
+ * @param {string} specifier The descendant module's static import specifier.
+ * @param {string} parentURL The descendant module URL.
+ * @param {CycleState} state The wrapper root and detected cycle edges.
+ */
+function inspectCyclicImport (specifier, parentURL, state) {
+  if (specifier.startsWith('node:')) return
+  addCyclicImport(specifier, parentURL, state)
+}
 
 function hasIitm (url) {
   // Fast path: avoid URL parsing on the hot path when there's clearly no iitm.
@@ -221,14 +255,35 @@ function shouldExcludeExport (name, sourceUrl) {
  * created lazily once `depth` crosses {@link STAR_CYCLE_DEPTH}. A URL is added
  * before descending into its subtree and removed once that subtree finishes, so
  * it tracks the active path rather than every URL ever visited.
+ * @param {string} [params.rootUrl = params.srcUrl] The wrapper root URL.
+ * @param {CycleState} [params.cycleState] The wrapper root and detected cycle edges.
  * @returns {Generator<Array, ProcessResult>}
  * A generator that yields I/O operations and ultimately returns the shimmed
  * bindings for all the exports from the module and any transitive export all
  * modules. `origins` (the defining module per `*`-sourced name) is `undefined`
  * for a module with no `export *`.
  */
-function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen }) {
-  const { exportNames, starReexports } = yield * getExports(srcUrl, context)
+function * processModule ({
+  srcUrl,
+  context,
+  excludeDefault = false,
+  depth = 0,
+  seen,
+  rootUrl = srcUrl,
+  cycleState
+}) {
+  let isCycleRoot = false
+  const moduleExports = yield * getExports(srcUrl, context, cycleState !== undefined)
+  const { exportNames, starReexports } = moduleExports
+
+  if (cycleState !== undefined) {
+    const { staticImports } = moduleExports
+    if (typeof staticImports === 'string') {
+      inspectCyclicImport(staticImports, srcUrl, cycleState)
+    } else if (staticImports !== undefined && staticImports !== false) {
+      for (const specifier of staticImports) inspectCyclicImport(specifier, srcUrl, cycleState)
+    }
+  }
 
   // Most modules have no export star. Keep that path array-backed so it pays
   // neither merge bookkeeping nor a Map lookup for each direct export.
@@ -243,6 +298,11 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
       bindings.push(name)
     }
     return { bindings, origins: undefined }
+  }
+
+  if (cycleState === undefined) {
+    cycleState = { rootUrl, imports: undefined }
+    isCycleRoot = true
   }
 
   const bindings = new Map()
@@ -308,7 +368,8 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
         context: { ...context, format: result.format },
         excludeDefault: true,
         depth: depth + 1,
-        seen
+        seen,
+        cycleState
       })
 
       for (const binding of sub.bindings.values()) {
@@ -341,10 +402,18 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
     }
   }
 
-  return { bindings, origins: starOrigins }
+  return isCycleRoot && cycleState.imports !== undefined
+    ? { bindings, origins: starOrigins, cyclicImports: cycleState.imports }
+    : { bindings, origins: starOrigins }
 }
 
 function addIitm (url) {
+  if (url.indexOf('?') === -1) {
+    const hashIndex = url.indexOf('#')
+    return hashIndex === -1
+      ? `${url}?iitm=true`
+      : `${url.slice(0, hashIndex)}?iitm=true${url.slice(hashIndex)}`
+  }
   const urlObj = new URL(url)
   urlObj.searchParams.set('iitm', 'true')
   return urlObj.href
@@ -356,11 +425,124 @@ function addIitm (url) {
 export function createHook (meta) {
   /** @type {Map<string, SpecifierData>} */
   const specifiers = new Map()
+  let specifierParentTargetURL
+  let specifierParentURL
+  /** @type {Map<string, string> | undefined} */
+  let specifierParents
+  /** @type {Map<string, InitiatingImport[]> | undefined} */
+  let duplicateSpecifiers
   let cachedResolve
   const iitmURL = new URL('lib/register.js', meta.url).toString()
   let includeModules, excludeModules
   let shouldInclude = defaultShouldInclude
   let disableCjsSourceStripping = false
+  /** @type {Map<string, CyclicImportTargets> | undefined} */
+  let cyclicImportTargets
+
+  /**
+   * @param {string} url The resolved wrapper target URL.
+   * @param {string} parentURL The importing module URL.
+   */
+  function storeSpecifierParent (url, parentURL) {
+    if (specifierParentTargetURL === undefined && specifierParents === undefined) {
+      specifierParentTargetURL = url
+      specifierParentURL = parentURL
+      return
+    }
+    if (specifierParentTargetURL !== undefined) {
+      specifierParents = new Map([[specifierParentTargetURL, specifierParentURL]])
+      specifierParentTargetURL = undefined
+      specifierParentURL = undefined
+    }
+    specifierParents.set(url, parentURL)
+  }
+
+  /**
+   * @param {string} url The resolved wrapper target URL.
+   * @returns {string | undefined}
+   */
+  function takeSpecifierParent (url) {
+    if (url === specifierParentTargetURL) {
+      const parentURL = specifierParentURL
+      specifierParentTargetURL = undefined
+      specifierParentURL = undefined
+      return parentURL
+    }
+    const parentURL = specifierParents.get(url)
+    specifierParents.delete(url)
+    if (specifierParents.size === 0) specifierParents = undefined
+    return parentURL
+  }
+
+  /**
+   * @param {string} url The resolved wrapper target URL.
+   * @returns {InitiatingImport[] | undefined}
+   */
+  function takeDuplicateSpecifiers (url) {
+    const entries = duplicateSpecifiers?.get(url)
+    if (entries === undefined) return
+    duplicateSpecifiers.delete(url)
+    if (duplicateSpecifiers.size === 0) duplicateSpecifiers = undefined
+    return entries
+  }
+
+  /**
+   * @param {Map<string, Map<string, string>>} imports Cycle candidates grouped by importing module.
+   * @param {InitiatingImport} initiatingImport An import that initiated the wrapper.
+   * @param {string} rootURL The wrapped module URL.
+   */
+  function removeCyclicImport (imports, initiatingImport, rootURL) {
+    const targets = imports.get(initiatingImport.parentURL)
+    if (targets?.get(initiatingImport.specifier) !== rootURL) return
+    targets.delete(initiatingImport.specifier)
+    if (targets.size === 0) imports.delete(initiatingImport.parentURL)
+  }
+
+  /**
+   * @param {Map<string, Map<string, string>> | undefined} imports Cycle candidates grouped by importing module.
+   * @param {InitiatingImport | InitiatingImport[]} initiatingImports Imports that initiated the wrapper.
+   * @param {string} rootURL The wrapped module URL.
+   */
+  function mergeCyclicImports (imports, initiatingImports, rootURL) {
+    if (imports === undefined) return
+
+    if (Array.isArray(initiatingImports)) {
+      for (const initiatingImport of initiatingImports) removeCyclicImport(imports, initiatingImport, rootURL)
+    } else {
+      removeCyclicImport(imports, initiatingImports, rootURL)
+    }
+    if (imports.size === 0) return
+
+    cyclicImportTargets ??= new Map()
+    for (const [parentURL, newTargets] of imports) {
+      const targets = cyclicImportTargets.get(parentURL)
+      if (targets === undefined) {
+        cyclicImportTargets.set(parentURL, newTargets)
+        continue
+      }
+      for (const [specifier, targetURL] of newTargets) {
+        const previous = targets.get(specifier)
+        if (previous === undefined) {
+          targets.set(specifier, targetURL)
+        } else if (typeof previous === 'string') {
+          if (previous !== targetURL) targets.set(specifier, new Set([previous, targetURL]))
+        } else {
+          previous.add(targetURL)
+        }
+      }
+    }
+  }
+
+  /**
+   * @param {string} parentURL The importing module URL.
+   * @param {Map<string, CyclicImportTargets> | undefined} imports The captured cycle candidate registry.
+   * @param {CyclicImportTargets | undefined} targets The captured candidates for the importing module.
+   */
+  function clearCyclicImports (parentURL, imports, targets) {
+    if (imports?.get(parentURL) !== targets) return
+    imports.delete(parentURL)
+    if (imports === cyclicImportTargets && imports.size === 0) cyclicImportTargets = undefined
+  }
 
   // Track CJS module URLs that IITM has wrapped. On Node 24+, CJS modules loaded
   // via loadCJSModule (in an ESM import chain) have their require() calls for
@@ -462,7 +644,15 @@ export function createHook (meta) {
   // once the parent loader has turned the specifier into a resolved URL. The
   // only difference between the asynchronous and synchronous hooks is whether
   // that resolution was awaited, so all the wrapping decisions live here.
-  function finishResolve (result, specifier, context, parentURL) {
+  /**
+   * @param {{ url: string, format?: string }} result The resolved module.
+   * @param {string} specifier The original module specifier.
+   * @param {LoadContext} context The resolve context.
+   * @param {string} parentURL The importing module URL.
+   * @param {Map<string, CyclicImportTargets> | undefined} cyclicImports The captured cycle candidate registry.
+   * @param {CyclicImportTargets | undefined} cyclicTargets The captured candidates for the importing module.
+   */
+  function finishResolve (result, specifier, context, parentURL, cyclicImports, cyclicTargets) {
     // Do not wrap the entrypoint module. Many CLIs check whether they are the
     // "main" module (e.g. require.main === module). Wrapping changes how they
     // are evaluated, and can make them exit without doing anything.
@@ -471,6 +661,21 @@ export function createHook (meta) {
         return { url: result.url, format: 'commonjs' }
       }
       return result
+    }
+
+    let currentImports = cyclicImports
+    let currentTargets = cyclicTargets
+    if (cyclicImports === cyclicImportTargets) {
+      if (cyclicImports !== undefined) currentTargets = cyclicImports.get(parentURL)
+    } else {
+      currentImports = cyclicImportTargets
+      currentTargets = currentImports?.get(parentURL)
+    }
+    const target = currentTargets?.get(specifier)
+    if (target !== undefined) {
+      currentTargets.delete(specifier)
+      if (currentTargets.size === 0) clearCyclicImports(parentURL, currentImports, currentTargets)
+      if (typeof target === 'string' ? target === result.url : target.has(result.url)) return result
     }
 
     // Never wrap a module whose format we don't handle (e.g. json, wasm); this
@@ -537,6 +742,37 @@ export function createHook (meta) {
     const specifierData = result.format === 'module-typescript' || result.format === 'commonjs-typescript'
       ? { specifier, format: result.format }
       : specifier
+    const previousSpecifierData = specifiers.get(result.url)
+    if (previousSpecifierData === undefined) {
+      storeSpecifierParent(result.url, parentURL)
+    } else {
+      let entries = duplicateSpecifiers?.get(result.url)
+      if (entries === undefined) {
+        const previousSpecifier = typeof previousSpecifierData === 'string'
+          ? previousSpecifierData
+          : previousSpecifierData.specifier
+        const previousParentURL = takeSpecifierParent(result.url)
+        if (previousSpecifier === specifier && previousParentURL === parentURL) {
+          storeSpecifierParent(result.url, parentURL)
+        } else {
+          entries = [
+            { specifier: previousSpecifier, parentURL: previousParentURL },
+            { specifier, parentURL }
+          ]
+          duplicateSpecifiers ??= new Map()
+          duplicateSpecifiers.set(result.url, entries)
+        }
+      } else {
+        let duplicate = false
+        for (const entry of entries) {
+          if (entry.specifier === specifier && entry.parentURL === parentURL) {
+            duplicate = true
+            break
+          }
+        }
+        if (!duplicate) entries.push({ specifier, parentURL })
+      }
+    }
     specifiers.set(result.url, specifierData)
 
     return {
@@ -565,9 +801,21 @@ export function createHook (meta) {
     if (isWin && parentURL.indexOf('file:node') === 0) {
       context.parentURL = ''
     }
-    const result = await parentResolve(newSpecifier, context)
+    const cyclicImports = cyclicImportTargets
+    const cyclicTargets = cyclicImports?.get(parentURL)
+    let result
+    if (cyclicTargets === undefined) {
+      result = await parentResolve(newSpecifier, context)
+    } else {
+      try {
+        result = await parentResolve(newSpecifier, context)
+      } catch (error) {
+        clearCyclicImports(parentURL, cyclicImports, cyclicTargets)
+        throw error
+      }
+    }
 
-    return finishResolve(result, specifier, context, parentURL)
+    return finishResolve(result, specifier, context, parentURL, cyclicImports, cyclicTargets)
   }
 
   // Synchronous counterpart to `resolve`, for `module.registerHooks`. The
@@ -589,9 +837,21 @@ export function createHook (meta) {
     if (isWin && parentURL.indexOf('file:node') === 0) {
       context.parentURL = ''
     }
-    const result = nextResolve(newSpecifier, context)
+    const cyclicImports = cyclicImportTargets
+    const cyclicTargets = cyclicImports?.get(parentURL)
+    let result
+    if (cyclicTargets === undefined) {
+      result = nextResolve(newSpecifier, context)
+    } else {
+      try {
+        result = nextResolve(newSpecifier, context)
+      } catch (error) {
+        clearCyclicImports(parentURL, cyclicImports, cyclicTargets)
+        throw error
+      }
+    }
 
-    return finishResolve(result, specifier, context, parentURL)
+    return finishResolve(result, specifier, context, parentURL, cyclicImports, cyclicTargets)
   }
 
   /**
@@ -719,6 +979,8 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
         specifiers.delete(url)
         return parentGetSource(url, context)
       }
+      const duplicateEntries = takeDuplicateSpecifiers(realUrl)
+      const parentURL = duplicateEntries === undefined ? takeSpecifierParent(realUrl) : undefined
 
       let originalSpecifier = specifierData
       let processContext = context
@@ -728,11 +990,14 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
       }
 
       try {
-        const { bindings } = await driveAsync(
+        const { bindings, cyclicImports } = await driveAsync(
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: parentGetSource }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings) }
+        const source = onWrapSuccess(realUrl, processContext, originalSpecifier, bindings)
+        const initiatingImports = duplicateEntries ?? { specifier: originalSpecifier, parentURL }
+        mergeCyclicImports(cyclicImports, initiatingImports, realUrl)
+        return { source }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         // Revert back to the non-iitm URL
@@ -759,6 +1024,8 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
         specifiers.delete(url)
         return nextLoad(url, context)
       }
+      const duplicateEntries = takeDuplicateSpecifiers(realUrl)
+      const parentURL = duplicateEntries === undefined ? takeSpecifierParent(realUrl) : undefined
 
       let originalSpecifier = specifierData
       let processContext = context
@@ -768,11 +1035,14 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
       }
 
       try {
-        const { bindings } = driveSync(
+        const { bindings, cyclicImports } = driveSync(
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: nextLoad }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings) }
+        const source = onWrapSuccess(realUrl, processContext, originalSpecifier, bindings)
+        const initiatingImports = duplicateEntries ?? { specifier: originalSpecifier, parentURL }
+        mergeCyclicImports(cyclicImports, initiatingImports, realUrl)
+        return { source }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         url = realUrl

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -468,6 +468,7 @@ export function createHook (meta) {
       specifierParentURL = undefined
       return parentURL
     }
+    if (specifierParents === undefined) return
     const parentURL = specifierParents.get(url)
     specifierParents.delete(url)
     if (specifierParents.size === 0) specifierParents = undefined
@@ -752,13 +753,17 @@ export function createHook (meta) {
           ? previousSpecifierData
           : previousSpecifierData.specifier
         const previousParentURL = takeSpecifierParent(result.url)
-        if (previousSpecifier === specifier && previousParentURL === parentURL) {
+        if (previousParentURL === undefined) {
+          entries = [{ specifier, parentURL }]
+        } else if (previousSpecifier === specifier && previousParentURL === parentURL) {
           storeSpecifierParent(result.url, parentURL)
         } else {
           entries = [
             { specifier: previousSpecifier, parentURL: previousParentURL },
             { specifier, parentURL }
           ]
+        }
+        if (entries !== undefined) {
           duplicateSpecifiers ??= new Map()
           duplicateSpecifiers.set(result.url, entries)
         }
@@ -994,11 +999,21 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: parentGetSource }
         )
+        const racedEntries = takeDuplicateSpecifiers(realUrl)
         const source = onWrapSuccess(realUrl, processContext, originalSpecifier, bindings)
-        const initiatingImports = duplicateEntries ?? { specifier: originalSpecifier, parentURL }
+        let initiatingImports = duplicateEntries ?? { specifier: originalSpecifier, parentURL }
+        if (racedEntries !== undefined) {
+          if (Array.isArray(initiatingImports)) {
+            for (const entry of racedEntries) initiatingImports.push(entry)
+          } else {
+            racedEntries.push(initiatingImports)
+            initiatingImports = racedEntries
+          }
+        }
         mergeCyclicImports(cyclicImports, initiatingImports, realUrl)
         return { source }
       } catch (cause) {
+        takeDuplicateSpecifiers(realUrl)
         onWrapFailure(realUrl, cause)
         // Revert back to the non-iitm URL
         url = realUrl

--- a/lib/get-esm-exports.mjs
+++ b/lib/get-esm-exports.mjs
@@ -6,6 +6,7 @@ import { parse } from 'es-module-lexer'
  * @typedef {object} LexedExports
  * @property {string[] | Set<string>} exportNames
  * @property {Array<{ specifier: string, parentURL: string }> | undefined} starReexports
+ * @property {false | string | string[] | undefined} [staticImports]
  * @property {boolean} hasModuleSyntax
  */
 
@@ -86,4 +87,44 @@ export function lexEsm (moduleSource, parentURL) {
   }
 
   return { exportNames, starReexports, hasModuleSyntax }
+}
+
+/**
+ * Retains static import specifiers while processing a star re-export graph.
+ *
+ * @param {string} moduleSource The source code of the module to lex.
+ * @param {string} parentURL The URL of the module declaring star re-exports.
+ * @returns {LexedExports & { staticImports: false | string | string[] }}
+ */
+export function lexEsmWithStaticImports (moduleSource, parentURL) {
+  const exportNames = []
+  let starReexports
+  let staticImports = false
+  const [imports, exports, , hasModuleSyntax] = parse(moduleSource)
+
+  if (moduleSource.indexOf('import') !== -1) {
+    for (const imported of imports) {
+      if (imported.type !== 'static' || imported.typeOnly) continue
+      if (moduleSource.charCodeAt(imported.importStart) !== 105) continue
+      if (staticImports === false) {
+        staticImports = imported.specifier
+      } else if (typeof staticImports === 'string') {
+        staticImports = [staticImports, imported.specifier]
+      } else {
+        staticImports.push(imported.specifier)
+      }
+    }
+  }
+
+  for (const exported of exports) {
+    if (exported.typeOnly) continue
+
+    if (exported.type === 'reexport-all') {
+      (starReexports ??= []).push({ specifier: exported.from, parentURL })
+    } else {
+      exportNames.push(decodeExportName(exported.name))
+    }
+  }
+
+  return { exportNames, starReexports, staticImports, hasModuleSyntax }
 }

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -1,6 +1,6 @@
 'use strict'
 
-import { lexEsm } from './get-esm-exports.mjs'
+import { lexEsm, lexEsmWithStaticImports } from './get-esm-exports.mjs'
 import { parse as parseCjs, initSync } from 'cjs-module-lexer'
 import { readFileSync, existsSync } from 'fs'
 import { builtinModules, createRequire } from 'module'
@@ -12,7 +12,12 @@ const nodeMajor = Number(process.versions.node.split('.')[0])
 export const hasModuleExportsCJSDefault = nodeMajor >= 23
 
 /** @typedef {{ specifier: string, parentURL: string }} StarReexport */
-/** @typedef {{ exportNames: Iterable<string>, starReexports?: StarReexport[] }} ModuleExports */
+/**
+ * @typedef {object} ModuleExports
+ * @property {Iterable<string>} exportNames
+ * @property {StarReexport[]} [starReexports]
+ * @property {false | string | string[] | undefined} [staticImports]
+ */
 
 let parserInitialized = false
 let stripTypeScriptTypes
@@ -239,14 +244,15 @@ function * getCjsExports (url, context, source) {
  * get the exports of.
  * @param {object} context Context object as provided by the `load` hook from
  * the loaders API.
+ * @param {boolean} [includeStaticImports = false] Include static ESM import specifiers.
  *
  * @returns {Generator<Array, ModuleExports>} A generator that yields I/O
  * operations and ultimately returns the identifiers and star re-exports of the
  * module.
  */
-export function * getExports (url, context) {
+export function * getExports (url, context, includeStaticImports = false) {
   const cached = esmExportsCache.get(url)
-  if (cached !== undefined) {
+  if (cached !== undefined && (!includeStaticImports || cached.staticImports !== undefined)) {
     return cached
   }
 
@@ -299,8 +305,11 @@ export function * getExports (url, context) {
       return yield * getCjsExports(url, context, source)
     }
 
-    const { exportNames, starReexports, hasModuleSyntax } = lexEsm(source, url)
+    const { exportNames, starReexports, staticImports, hasModuleSyntax } = includeStaticImports
+      ? lexEsmWithStaticImports(source, url)
+      : lexEsm(source, url)
     const moduleExports = starReexports === undefined ? { exportNames } : { exportNames, starReexports }
+    if (includeStaticImports) moduleExports.staticImports = staticImports
 
     if (moduleFormat === 'module') {
       esmExportsCache.set(url, moduleExports)

--- a/test/fixtures/cached-resolution-retention.mjs
+++ b/test/fixtures/cached-resolution-retention.mjs
@@ -1,0 +1,12 @@
+import Hook from '../../index.js'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (supportsSyncHooks()) {
+  register()
+  const hook = new Hook(() => {})
+  const targetURL = new URL('./specifier-string.js', import.meta.url)
+  await import(targetURL)
+  global.gc()
+  for (let index = 0; index < 1_000_000; index++) await import(targetURL)
+  hook.unhook()
+}

--- a/test/fixtures/circular-reexport-barrel.mjs
+++ b/test/fixtures/circular-reexport-barrel.mjs
@@ -1,0 +1,2 @@
+export * from './circular-reexport-error.mjs'
+export * from './circular-reexport-registry.mjs'

--- a/test/fixtures/circular-reexport-consumer.mjs
+++ b/test/fixtures/circular-reexport-consumer.mjs
@@ -1,0 +1,10 @@
+import 'node:assert'
+
+import { UserError } from './circular-reexport-barrel.mjs'
+import { UserError as AliasedUserError } from '#circular-reexport-barrel'
+
+export class RegistryError extends UserError {}
+export const sameUserError = AliasedUserError === UserError
+export function importCircularExports () {
+  return import('./circular-reexport-barrel.mjs')
+}

--- a/test/fixtures/circular-reexport-entry.mjs
+++ b/test/fixtures/circular-reexport-entry.mjs
@@ -1,0 +1,3 @@
+import * as circularExports from './circular-reexport-barrel.mjs'
+
+export default circularExports

--- a/test/fixtures/circular-reexport-error.mjs
+++ b/test/fixtures/circular-reexport-error.mjs
@@ -1,0 +1,3 @@
+import 'node:assert'
+
+export class UserError extends Error {}

--- a/test/fixtures/circular-reexport-registry.mjs
+++ b/test/fixtures/circular-reexport-registry.mjs
@@ -1,0 +1,1 @@
+export * from './circular-reexport-consumer.mjs'

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -33,6 +33,7 @@
         }
       },
       "#main-entry-point-string" : "./something.js",
-      "#main-entry-point-external" : "some-external-cjs-module"
+      "#main-entry-point-external" : "some-external-cjs-module",
+      "#circular-reexport-barrel": "./circular-reexport-barrel.mjs"
     }
 }

--- a/test/get-esm-exports/v20-get-esm-exports.mjs
+++ b/test/get-esm-exports/v20-get-esm-exports.mjs
@@ -1,6 +1,6 @@
 'use strict'
 
-import getEsmExports, { lexEsm } from '../../lib/get-esm-exports.mjs'
+import getEsmExports, { lexEsm, lexEsmWithStaticImports } from '../../lib/get-esm-exports.mjs'
 import fs from 'fs'
 import assert from 'assert'
 import path from 'path'
@@ -32,6 +32,33 @@ assert.deepEqual(lexEsm('export const direct = 1; export * from "dependency"', '
   starReexports: [{ specifier: 'dependency', parentURL: 'file:///parent.mjs' }],
   hasModuleSyntax: true
 })
+assert.deepEqual(
+  lexEsmWithStaticImports(
+    'import value from "dependency"; export * from "star"; export { other } from "named"; export { value }',
+    'file:///parent.mjs'
+  ),
+  {
+    exportNames: ['other', 'value'],
+    starReexports: [{ specifier: 'star', parentURL: 'file:///parent.mjs' }],
+    staticImports: 'dependency',
+    hasModuleSyntax: true
+  }
+)
+assert.deepEqual(lexEsmWithStaticImports('export * from "star"', 'file:///parent.mjs'), {
+  exportNames: [],
+  starReexports: [{ specifier: 'star', parentURL: 'file:///parent.mjs' }],
+  staticImports: false,
+  hasModuleSyntax: true
+})
+assert.deepEqual(
+  lexEsmWithStaticImports('import type { Type } from "types"; export type { Type }', 'file:///parent.mjs'),
+  {
+    exportNames: [],
+    starReexports: undefined,
+    staticImports: false,
+    hasModuleSyntax: true
+  }
+)
 
 // // Generate fixture data
 // fixture.split('\n').forEach(line => {

--- a/test/hook/v16.16-circular-reexport-consumer-first.mjs
+++ b/test/hook/v16.16-circular-reexport-consumer-first.mjs
@@ -1,0 +1,16 @@
+import { strictEqual } from 'node:assert'
+import Hook from '../../index.js'
+
+class HookedUserError extends Error {}
+
+const hook = new Hook((exports, name) => {
+  if (name.endsWith('circular-reexport-barrel.mjs')) exports.UserError = HookedUserError
+})
+
+const { RegistryError, importCircularExports } = await import('../fixtures/circular-reexport-consumer.mjs')
+const circularExports = await importCircularExports()
+
+strictEqual(circularExports.UserError, HookedUserError)
+strictEqual(RegistryError.prototype instanceof HookedUserError, true)
+
+hook.unhook()

--- a/test/hook/v16.16-circular-reexport-initialization.mjs
+++ b/test/hook/v16.16-circular-reexport-initialization.mjs
@@ -1,0 +1,19 @@
+import { strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+let barrelHooked = false
+let consumerHooked = false
+const hook = new Hook((exports, name) => {
+  if (name.endsWith('circular-reexport-barrel.mjs')) barrelHooked = true
+  if (name.endsWith('circular-reexport-consumer.mjs')) consumerHooked = true
+})
+
+const { default: circularExports } = await import('../fixtures/circular-reexport-entry.mjs')
+const { RegistryError, UserError, sameUserError } = circularExports
+
+strictEqual(barrelHooked, true)
+strictEqual(consumerHooked, true)
+strictEqual(RegistryError.prototype instanceof UserError, true)
+strictEqual(sameUserError, true)
+
+hook.unhook()

--- a/test/low-level/circular-reexport-resolve-cleanup.mjs
+++ b/test/low-level/circular-reexport-resolve-cleanup.mjs
@@ -365,3 +365,90 @@ pendingInstallSignal.emit('resolved', {
 })
 const pendingInstallCycle = await pendingInstallResolve
 strictEqual(pendingInstallCycle.url, pendingInstallLoader.rootURLs[0])
+
+const concurrentLoadExistingRootURL = 'file:///async-concurrent-load-existing-root.mjs'
+const concurrentLoadRootURL = 'file:///async-concurrent-load-root.mjs'
+const concurrentLoadLeafURL = 'file:///async-concurrent-load-leaf.mjs'
+const concurrentLoadExistingBackEdge = './async-concurrent-load-existing-root.mjs'
+const concurrentLoadBackEdge = './async-concurrent-load-root.mjs'
+const concurrentLoadSources = new Map([
+  [concurrentLoadExistingRootURL, "export * from './async-concurrent-load-leaf.mjs'"],
+  [concurrentLoadRootURL, "export * from './async-concurrent-load-leaf.mjs'"],
+  [concurrentLoadLeafURL, `
+import '${concurrentLoadExistingBackEdge}'
+import '${concurrentLoadBackEdge}'
+export const value = 1
+`]
+])
+const concurrentLoadSignal = new EventEmitter()
+let pauseConcurrentLoad = false
+
+/**
+ * @param {string} specifier The module specifier.
+ * @param {{ parentURL?: string }} context The resolve context.
+ */
+async function resolveConcurrentLoad (specifier, context) {
+  if (pauseConcurrentLoad && specifier === concurrentLoadLeafURL) {
+    pauseConcurrentLoad = false
+    concurrentLoadSignal.emit('pending')
+    await once(concurrentLoadSignal, 'continue')
+  }
+  return { url: new URL(specifier, context.parentURL).href, format: 'module', shortCircuit: true }
+}
+
+/** @param {string} url The module URL. */
+function loadConcurrentModule (url) {
+  return { format: 'module', source: concurrentLoadSources.get(url), shortCircuit: true }
+}
+
+const concurrentLoadHook = createHook(meta)
+const concurrentLoadExistingWrapper = await concurrentLoadHook.resolve(
+  concurrentLoadExistingRootURL,
+  { parentURL: 'file:///async-concurrent-load-existing-entry.mjs', conditions },
+  resolveConcurrentLoad
+)
+await concurrentLoadHook.load(
+  concurrentLoadExistingWrapper.url,
+  { format: 'module' },
+  loadConcurrentModule
+)
+const concurrentLoadConsumedCycle = await concurrentLoadHook.resolve(
+  concurrentLoadBackEdge,
+  { parentURL: concurrentLoadLeafURL, conditions },
+  () => ({ url: concurrentLoadExistingRootURL, format: 'module', shortCircuit: true })
+)
+strictEqual(concurrentLoadConsumedCycle.url, concurrentLoadExistingRootURL)
+
+const concurrentLoadWrapper = await concurrentLoadHook.resolve(
+  concurrentLoadRootURL,
+  { parentURL: 'file:///async-concurrent-load-entry.mjs', conditions },
+  resolveConcurrentLoad
+)
+pauseConcurrentLoad = true
+const concurrentScanPending = once(concurrentLoadSignal, 'pending')
+const concurrentLoad = concurrentLoadHook.load(
+  concurrentLoadWrapper.url,
+  { format: 'module' },
+  loadConcurrentModule
+)
+await concurrentScanPending
+const concurrentResolve = await concurrentLoadHook.resolve(
+  concurrentLoadBackEdge,
+  { parentURL: concurrentLoadLeafURL, conditions },
+  resolveConcurrentLoad
+)
+strictEqual(new URL(concurrentResolve.url).searchParams.get('iitm'), 'true')
+concurrentLoadSignal.emit('continue')
+await concurrentLoad
+const concurrentRetry = await concurrentLoadHook.resolve(
+  concurrentLoadBackEdge,
+  { parentURL: concurrentLoadLeafURL, conditions },
+  resolveConcurrentLoad
+)
+strictEqual(new URL(concurrentRetry.url).searchParams.get('iitm'), 'true')
+const concurrentExistingRetry = await concurrentLoadHook.resolve(
+  concurrentLoadExistingBackEdge,
+  { parentURL: concurrentLoadLeafURL, conditions },
+  resolveConcurrentLoad
+)
+strictEqual(concurrentExistingRetry.url, concurrentLoadExistingRootURL)

--- a/test/low-level/circular-reexport-resolve-cleanup.mjs
+++ b/test/low-level/circular-reexport-resolve-cleanup.mjs
@@ -1,0 +1,367 @@
+import { rejects, strictEqual, throws } from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { EventEmitter, once } from 'node:events'
+import { fileURLToPath } from 'node:url'
+
+import { createHook } from '../../create-hook.mjs'
+
+const meta = { url: new URL('../../hook.mjs', import.meta.url).href }
+const conditions = ['import']
+const missingError = Object.assign(new Error('missing module'), { code: 'ERR_MODULE_NOT_FOUND' })
+
+/**
+ * @param {string} prefix A unique file URL prefix for one hook mode.
+ */
+function createVirtualLoader (prefix) {
+  const rootURLs = [1, 2, 3].map(index => `file:///${prefix}-root-${index}.mjs`)
+  const consumerURL = `file:///${prefix}-consumer.mjs`
+  const sources = new Map([
+    ...rootURLs.map(rootURL => [
+      rootURL,
+      `export * from './${prefix}-error.mjs'; export * from './${prefix}-registry.mjs'`
+    ]),
+    [`file:///${prefix}-error.mjs`, 'export class UserError extends Error {}'],
+    [`file:///${prefix}-registry.mjs`, `export * from './${prefix}-consumer.mjs'`],
+    [consumerURL, `
+import { UserError } from '${prefix}-alias'
+import './${prefix}-root-1.mjs'
+import './${prefix}-root-2.mjs'
+import './${prefix}-relative-alias.mjs'
+export class RegistryError extends UserError {}`]
+  ])
+
+  /**
+   * @param {string} specifier The module specifier.
+   * @param {{ parentURL?: string }} context The resolve context.
+   */
+  function nextResolve (specifier, context) {
+    if (specifier === `${prefix}-alias`) {
+      return { url: rootURLs[0], format: 'module', shortCircuit: true }
+    }
+    if (specifier === `./${prefix}-relative-alias.mjs`) {
+      return { url: rootURLs[2], format: 'module', shortCircuit: true }
+    }
+    return { url: new URL(specifier, context.parentURL).href, format: 'module', shortCircuit: true }
+  }
+
+  /**
+   * @param {string} url The module URL.
+   */
+  function nextLoad (url) {
+    return { format: 'module', source: sources.get(url), shortCircuit: true }
+  }
+
+  return { prefix, rootURLs, consumerURL, nextResolve, nextLoad }
+}
+
+/**
+ * @param {ReturnType<typeof createHook>} hook The hook under test.
+ * @param {ReturnType<typeof createVirtualLoader>} loader The virtual module loader.
+ * @param {number} rootIndex The root module index.
+ */
+async function loadAsyncRoot (hook, loader, rootIndex) {
+  const wrapper = await hook.resolve(
+    loader.rootURLs[rootIndex],
+    { parentURL: `file:///${loader.prefix}-entry.mjs`, conditions },
+    loader.nextResolve
+  )
+  await hook.load(wrapper.url, { format: 'module' }, loader.nextLoad)
+}
+
+/**
+ * @param {ReturnType<typeof createHook>} hook The hook under test.
+ * @param {ReturnType<typeof createVirtualLoader>} loader The virtual module loader.
+ */
+async function consumeAsyncCycleCandidates (hook, loader) {
+  await Promise.all([
+    hook.resolve(
+      `${loader.prefix}-alias`,
+      { parentURL: loader.consumerURL, conditions },
+      loader.nextResolve
+    ),
+    hook.resolve(
+      `./${loader.prefix}-root-1.mjs`,
+      { parentURL: loader.consumerURL, conditions },
+      loader.nextResolve
+    ),
+    hook.resolve(
+      `./${loader.prefix}-root-2.mjs`,
+      { parentURL: loader.consumerURL, conditions },
+      loader.nextResolve
+    ),
+    hook.resolve(
+      `./${loader.prefix}-relative-alias.mjs`,
+      { parentURL: loader.consumerURL, conditions },
+      loader.nextResolve
+    )
+  ])
+}
+
+function failResolve () {
+  throw missingError
+}
+
+const dedupeLoader = createVirtualLoader('dedupe-cycle')
+const dedupeHook = createHook(meta)
+const dedupeResult = { url: dedupeLoader.rootURLs[0], format: 'module', shortCircuit: true }
+function resolveDedupeRoot () {
+  return dedupeResult
+}
+const firstDedupeWrapper = dedupeHook.resolveSync(
+  'dedupe-first-alias',
+  { parentURL: 'file:///dedupe-first-parent.mjs', conditions },
+  resolveDedupeRoot
+)
+dedupeHook.resolveSync(
+  'dedupe-first-alias',
+  { parentURL: 'file:///dedupe-first-parent.mjs', conditions },
+  resolveDedupeRoot
+)
+dedupeHook.resolveSync(
+  'dedupe-second-alias',
+  { parentURL: 'file:///dedupe-second-parent.mjs', conditions },
+  resolveDedupeRoot
+)
+dedupeHook.resolveSync(
+  'dedupe-first-alias',
+  { parentURL: 'file:///dedupe-first-parent.mjs', conditions },
+  resolveDedupeRoot
+)
+dedupeHook.resolveSync(
+  'dedupe-first-alias',
+  { parentURL: 'file:///dedupe-first-parent.mjs', conditions },
+  resolveDedupeRoot
+)
+const { source: dedupeSource } = dedupeHook.loadSync(
+  firstDedupeWrapper.url,
+  { format: 'module' },
+  dedupeLoader.nextLoad
+)
+strictEqual(dedupeSource.includes('dedupe-second-alias'), false)
+strictEqual(dedupeSource.includes('dedupe-first-alias'), true)
+
+const retentionChild = spawnSync(process.execPath, [
+  '--expose-gc',
+  '--max-old-space-size=32',
+  fileURLToPath(new URL('../fixtures/cached-resolution-retention.mjs', import.meta.url))
+], {
+  env: { ...process.env, NODE_OPTIONS: '', NODE_V8_COVERAGE: '' }
+})
+strictEqual(retentionChild.status, 0, retentionChild.stderr.toString())
+
+const syncLoader = createVirtualLoader('sync-cycle')
+const syncHook = createHook(meta)
+const firstSyncWrapper = syncHook.resolveSync(
+  syncLoader.rootURLs[0],
+  { parentURL: 'file:///sync-entry.mjs', conditions },
+  syncLoader.nextResolve
+)
+syncHook.loadSync(firstSyncWrapper.url, { format: 'module' }, syncLoader.nextLoad)
+const syncDirectCycle = syncHook.resolveSync(
+  './sync-cycle-root-1.mjs',
+  { parentURL: syncLoader.consumerURL, conditions },
+  syncLoader.nextResolve
+)
+strictEqual(syncDirectCycle.url, syncLoader.rootURLs[0])
+for (const rootURL of syncLoader.rootURLs.slice(1)) {
+  const syncWrapper = syncHook.resolveSync(
+    rootURL,
+    { parentURL: 'file:///sync-entry.mjs', conditions },
+    syncLoader.nextResolve
+  )
+  syncHook.loadSync(syncWrapper.url, { format: 'module' }, syncLoader.nextLoad)
+}
+
+const syncCycle = syncHook.resolveSync(
+  'sync-cycle-alias',
+  { parentURL: syncLoader.consumerURL, conditions },
+  syncLoader.nextResolve
+)
+strictEqual(syncCycle.url, syncLoader.rootURLs[0])
+const syncRelativeCycle = syncHook.resolveSync(
+  './sync-cycle-relative-alias.mjs',
+  { parentURL: syncLoader.consumerURL, conditions },
+  syncLoader.nextResolve
+)
+strictEqual(syncRelativeCycle.url, syncLoader.rootURLs[2])
+
+function resolveSyncMissing () {
+  return syncHook.resolveSync(
+    './missing.mjs',
+    { parentURL: syncLoader.consumerURL, conditions },
+    failResolve
+  )
+}
+
+throws(resolveSyncMissing, { code: 'ERR_MODULE_NOT_FOUND' })
+const syncRetry = syncHook.resolveSync(
+  'sync-cycle-alias',
+  { parentURL: syncLoader.consumerURL, conditions },
+  syncLoader.nextResolve
+)
+strictEqual(new URL(syncRetry.url).searchParams.get('iitm'), 'true')
+
+const nonLeafRootURL = 'file:///non-leaf-root.mjs'
+const nonLeafBridgeURL = 'file:///non-leaf-bridge.mjs'
+const nonLeafSources = new Map([
+  [nonLeafRootURL, "export * from './non-leaf-bridge.mjs'"],
+  [nonLeafBridgeURL, "import './non-leaf-root.mjs'; export * from './non-leaf-value.mjs'"],
+  ['file:///non-leaf-value.mjs', 'export const value = 1']
+])
+
+/**
+ * @param {string} specifier The module specifier.
+ * @param {{ parentURL?: string }} context The resolve context.
+ */
+function resolveNonLeaf (specifier, context) {
+  return { url: new URL(specifier, context.parentURL).href, format: 'module', shortCircuit: true }
+}
+
+/** @param {string} url The module URL. */
+function loadNonLeaf (url) {
+  return { format: 'module', source: nonLeafSources.get(url), shortCircuit: true }
+}
+
+const nonLeafHook = createHook(meta)
+const nonLeafWrapper = nonLeafHook.resolveSync(
+  nonLeafRootURL,
+  { parentURL: 'file:///non-leaf-entry.mjs', conditions },
+  resolveNonLeaf
+)
+nonLeafHook.loadSync(nonLeafWrapper.url, { format: 'module' }, loadNonLeaf)
+const nonLeafCycle = nonLeafHook.resolveSync(
+  './non-leaf-root.mjs',
+  { parentURL: nonLeafBridgeURL, conditions },
+  resolveNonLeaf
+)
+strictEqual(nonLeafCycle.url, nonLeafRootURL)
+
+const duplicateTypeScriptHook = createHook(meta)
+const duplicateTypeScriptURL = 'file:///duplicate-typescript.ts'
+const duplicateTypeScriptResolve = () => ({
+  url: duplicateTypeScriptURL,
+  format: 'module-typescript',
+  shortCircuit: true
+})
+duplicateTypeScriptHook.resolveSync(
+  './duplicate-typescript.ts',
+  { parentURL: 'file:///first-typescript-parent.mjs', conditions },
+  duplicateTypeScriptResolve
+)
+const duplicateTypeScriptWrapper = duplicateTypeScriptHook.resolveSync(
+  './duplicate-typescript.ts',
+  { parentURL: 'file:///second-typescript-parent.mjs', conditions },
+  duplicateTypeScriptResolve
+)
+duplicateTypeScriptHook.loadSync(duplicateTypeScriptWrapper.url, { format: 'module-typescript' }, () => ({
+  format: 'module-typescript',
+  source: 'export const value: number = 1',
+  shortCircuit: true
+}))
+
+const asyncLoader = createVirtualLoader('async-cycle')
+const asyncHook = createHook(meta)
+const firstAsyncWrapper = await asyncHook.resolve(
+  asyncLoader.rootURLs[0],
+  { parentURL: 'file:///async-entry.mjs', conditions },
+  asyncLoader.nextResolve
+)
+await asyncHook.load(firstAsyncWrapper.url, { format: 'module' }, asyncLoader.nextLoad)
+const asyncDirectCycle = await asyncHook.resolve(
+  './async-cycle-root-1.mjs',
+  { parentURL: asyncLoader.consumerURL, conditions },
+  asyncLoader.nextResolve
+)
+strictEqual(asyncDirectCycle.url, asyncLoader.rootURLs[0])
+for (const rootURL of asyncLoader.rootURLs.slice(1)) {
+  const asyncWrapper = await asyncHook.resolve(
+    rootURL,
+    { parentURL: 'file:///async-entry.mjs', conditions },
+    asyncLoader.nextResolve
+  )
+  await asyncHook.load(asyncWrapper.url, { format: 'module' }, asyncLoader.nextLoad)
+}
+
+const asyncCycle = await asyncHook.resolve(
+  'async-cycle-alias',
+  { parentURL: asyncLoader.consumerURL, conditions },
+  asyncLoader.nextResolve
+)
+strictEqual(asyncCycle.url, asyncLoader.rootURLs[0])
+const asyncRelativeCycle = await asyncHook.resolve(
+  './async-cycle-relative-alias.mjs',
+  { parentURL: asyncLoader.consumerURL, conditions },
+  asyncLoader.nextResolve
+)
+strictEqual(asyncRelativeCycle.url, asyncLoader.rootURLs[2])
+
+await rejects(
+  asyncHook.resolve(
+    './missing.mjs',
+    { parentURL: asyncLoader.consumerURL, conditions },
+    failResolve
+  ),
+  { code: 'ERR_MODULE_NOT_FOUND' }
+)
+const asyncRetry = await asyncHook.resolve(
+  'async-cycle-alias',
+  { parentURL: asyncLoader.consumerURL, conditions },
+  asyncLoader.nextResolve
+)
+strictEqual(new URL(asyncRetry.url).searchParams.get('iitm'), 'true')
+
+const missingRaceLoader = createVirtualLoader('async-missing-race')
+const missingRaceHook = createHook(meta)
+await loadAsyncRoot(missingRaceHook, missingRaceLoader, 0)
+const missingRaceSignal = new EventEmitter()
+const pendingMissingResolve = missingRaceHook.resolve(
+  './missing.mjs',
+  { parentURL: missingRaceLoader.consumerURL, conditions },
+  () => once(missingRaceSignal, 'resolved')
+)
+await consumeAsyncCycleCandidates(missingRaceHook, missingRaceLoader)
+const missingRaceAssertion = rejects(pendingMissingResolve, { code: 'ERR_MODULE_NOT_FOUND' })
+missingRaceSignal.emit('error', missingError)
+await missingRaceAssertion
+
+const supersededRaceLoader = createVirtualLoader('async-superseded-race')
+const supersededRaceHook = createHook(meta)
+await loadAsyncRoot(supersededRaceHook, supersededRaceLoader, 0)
+const supersededRaceSignal = new EventEmitter()
+const pendingSupersededResolve = supersededRaceHook.resolve(
+  './missing.mjs',
+  { parentURL: supersededRaceLoader.consumerURL, conditions },
+  () => once(supersededRaceSignal, 'resolved')
+)
+await consumeAsyncCycleCandidates(supersededRaceHook, supersededRaceLoader)
+await loadAsyncRoot(supersededRaceHook, supersededRaceLoader, 1)
+const supersededRaceAssertion = rejects(pendingSupersededResolve, { code: 'ERR_MODULE_NOT_FOUND' })
+supersededRaceSignal.emit('error', missingError)
+await supersededRaceAssertion
+const supersededCycle = await supersededRaceHook.resolve(
+  'async-superseded-race-alias',
+  { parentURL: supersededRaceLoader.consumerURL, conditions },
+  () => ({ url: supersededRaceLoader.rootURLs[1], format: 'module', shortCircuit: true })
+)
+strictEqual(supersededCycle.url, supersededRaceLoader.rootURLs[1])
+
+const pendingInstallLoader = createVirtualLoader('async-pending-install')
+const pendingInstallHook = createHook(meta)
+const pendingInstallSignal = new EventEmitter()
+async function waitForPendingInstall () {
+  const [result] = await once(pendingInstallSignal, 'resolved')
+  return result
+}
+const pendingInstallResolve = pendingInstallHook.resolve(
+  'async-pending-install-alias',
+  { parentURL: pendingInstallLoader.consumerURL, conditions },
+  waitForPendingInstall
+)
+await loadAsyncRoot(pendingInstallHook, pendingInstallLoader, 0)
+pendingInstallSignal.emit('resolved', {
+  url: pendingInstallLoader.rootURLs[0],
+  format: 'module',
+  shortCircuit: true
+})
+const pendingInstallCycle = await pendingInstallResolve
+strictEqual(pendingInstallCycle.url, pendingInstallLoader.rootURLs[0])

--- a/test/register/v22.15-sync-circular-reexport-consumer-first.mjs
+++ b/test/register/v22.15-sync-circular-reexport-consumer-first.mjs
@@ -1,0 +1,24 @@
+import { strictEqual } from 'node:assert'
+import Hook from '../../index.js'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+register()
+
+class HookedUserError extends Error {}
+
+const hook = new Hook((exports, name) => {
+  if (name.endsWith('circular-reexport-barrel.mjs')) exports.UserError = HookedUserError
+})
+
+const { RegistryError, importCircularExports } = await import('../fixtures/circular-reexport-consumer.mjs')
+const circularExports = await importCircularExports()
+
+strictEqual(circularExports.UserError, HookedUserError)
+strictEqual(RegistryError.prototype instanceof HookedUserError, true)
+
+hook.unhook()

--- a/test/register/v22.15-sync-circular-reexport-initialization.mjs
+++ b/test/register/v22.15-sync-circular-reexport-initialization.mjs
@@ -1,0 +1,27 @@
+import { strictEqual } from 'node:assert'
+import Hook from '../../index.js'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
+  process.exit(0)
+}
+
+register()
+
+let barrelHooked = false
+let consumerHooked = false
+const hook = new Hook((exports, name) => {
+  if (name.endsWith('circular-reexport-barrel.mjs')) barrelHooked = true
+  if (name.endsWith('circular-reexport-consumer.mjs')) consumerHooked = true
+})
+
+const { default: circularExports } = await import('../fixtures/circular-reexport-entry.mjs')
+const { RegistryError, UserError, sameUserError } = circularExports
+
+strictEqual(barrelHooked, true)
+strictEqual(consumerHooked, true)
+strictEqual(RegistryError.prototype instanceof UserError, true)
+strictEqual(sameUserError, true)
+
+hook.unhook()


### PR DESCRIPTION
IITM replaces the native back-edge with an uninitialized wrapper binding when it wraps every edge in an ESM `export *` cycle. Valid class initialization then fails before the hook runs.

This keeps the matching static cycle edge unwrapped. Generation-scoped cleanup prevents older concurrent resolutions from deleting newer cycle state.

The ordinary 32,250-module path had no reproducible CPU or retained-heap regression. The active star graph used 2.22% less CPU and 0.42% more retained heap. Repeated cached imports measured 0.996x CPU and 0.908x retained heap versus `main`.

Fixes: https://github.com/nodejs/import-in-the-middle/issues/290