### PR TITLE
feat: add export replacement capabilities to hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ Hook(['package-i-want-to-modify'], (exported, name, baseDir) => {
 console.log(foo) // 1 more than whatever that module exported
 ```
 
+### Preserving live bindings
+
+By default, each hook can replace every export. IITM must create a local binding
+for each export because the hook can assign a new value to it.
+
+Use `replaceExports` to declare the bindings that a hook can replace. IITM keeps
+every other binding linked to its source module. An empty list is for hooks that
+only mutate nested properties. For ESM modules, it also avoids the generated
+binding cells and initialization work for every export.
+
+```js
+Hook(['package-i-want-to-instrument'], { replaceExports: [] }, (exported) => {
+  exported.Client.prototype.instrumented = true
+})
+```
+
+All hooks for a module contribute to the replacement set. A hook without
+`replaceExports` keeps the default behavior and makes every binding replaceable.
+The lower-level `addHook()` API also makes every binding replaceable because it
+does not filter modules.
+
+The loader must receive the capability before it resolves the module.
+Synchronous `register-hooks.mjs` registration shares it directly. Asynchronous
+registration requires `createAddHookMessageChannel()` and
+`waitForAllMessagesAcknowledged()`.
+
+The wrapper shape cannot change after Node.js links it. A hook registered after
+the import can mutate nested properties. It cannot replace a binding that the
+earlier hooks did not declare.
+
 This requires the use of an ESM loader hook, which can be added with the following
 command-line option.
 

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -7,6 +7,7 @@ import { inspect } from 'util'
 import { builtinModules } from 'module'
 import { getExports } from './lib/get-exports.mjs'
 import { RESOLVE, driveSync, driveAsync } from './lib/io.mjs'
+import getTurbopackSpecifier from './lib/turbopack.js'
 import { supportsSyncHooks } from './supports-sync-hooks.mjs'
 
 // Re-exported for backwards compatibility: `supportsSyncHooks` now lives in its
@@ -35,8 +36,27 @@ const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
 
 /** @typedef {import('node:module').LoadHookContext} LoadContext */
 /** @typedef {import('node:module').LoadFnOutput} LoadResult */
-/** @typedef {string | { specifier: string, format: 'module-typescript' | 'commonjs-typescript' }} SpecifierData */
+/**
+ * @typedef {string | {
+ *   specifier: string,
+ *   format?: 'module-typescript' | 'commonjs-typescript',
+ *   replaceExports?: ReadonlySet<string>
+ * }} SpecifierData
+ */
 /** @typedef {{ name: string, origin: string }} StarBinding */
+/**
+ * @typedef {object} HookCapability
+ * @property {number | undefined} id
+ * @property {string[] | undefined} modules
+ * @property {ReadonlyArray<string> | undefined} replaceExports
+ */
+/**
+ * @typedef {object} RegisteredHookCapability
+ * @property {number | undefined} id
+ * @property {string[] | undefined} modules
+ * @property {ReadonlySet<string> | undefined} replaceExports
+ */
+/** @typedef {{ id: number, removed: true }} HookCapabilityRemoval */
 /**
  * @typedef {object} ProcessResult
  * @property {string[] | Map<string, string | StarBinding>} bindings
@@ -352,13 +372,18 @@ function addIitm (url) {
 
 /**
  * @param {{ url: string }} meta
+ * @param {(listener: (capability: {
+ *   modules: string[] | undefined,
+ *   replaceExports: ReadonlyArray<string> | undefined
+ * }) => void) => void} [listenForHookCapabilities]
  */
-export function createHook (meta) {
+export function createHook (meta, listenForHookCapabilities) {
   /** @type {Map<string, SpecifierData>} */
   const specifiers = new Map()
   let cachedResolve
   const iitmURL = new URL('lib/register.js', meta.url).toString()
   let includeModules, excludeModules
+  let includeHookCapabilities = false
   let shouldInclude = defaultShouldInclude
   let disableCjsSourceStripping = false
 
@@ -369,6 +394,134 @@ export function createHook (meta) {
   // of the native CJS module value (e.g. EventEmitter constructor), breaking
   // patterns like `class App extends require('events') {}`.
   const cjsInIitmChain = new Set()
+  /** @type {RegisteredHookCapability[] | undefined} */
+  let registeredHookCapabilities
+  let hasExplicitHookCapabilities = false
+
+  /**
+   * @param {HookCapability} capability
+   * @returns {string[] | undefined}
+   */
+  function registerHookCapability (capability) {
+    let modules
+    if (capability.modules !== undefined) {
+      modules = capability.modules.slice()
+      for (const each of capability.modules) {
+        if (!each.startsWith('node:') && builtinModules.includes(each)) {
+          modules.push(`node:${each}`)
+        }
+      }
+    }
+
+    const replaceExports = capability.replaceExports === undefined
+      ? undefined
+      : new Set(capability.replaceExports)
+    if (replaceExports !== undefined) hasExplicitHookCapabilities = true
+    registeredHookCapabilities ??= []
+    registeredHookCapabilities.push({ id: capability.id, modules, replaceExports })
+    return modules
+  }
+
+  /**
+   * @param {number} id
+   */
+  function removeHookCapability (id) {
+    let index = -1
+    if (registeredHookCapabilities !== undefined) {
+      for (let i = 0; i < registeredHookCapabilities.length; i++) {
+        if (registeredHookCapabilities[i].id === id) {
+          index = i
+          break
+        }
+      }
+    }
+    if (index === -1) return
+    registeredHookCapabilities.splice(index, 1)
+    hasExplicitHookCapabilities = false
+    for (const capability of registeredHookCapabilities) {
+      if (capability.replaceExports !== undefined) {
+        hasExplicitHookCapabilities = true
+        break
+      }
+    }
+  }
+
+  /**
+   * @param {HookCapability | HookCapabilityRemoval} update
+   * @returns {string[] | undefined}
+   */
+  function applyHookCapabilityUpdate (update) {
+    if ('removed' in update) {
+      removeHookCapability(update.id)
+      return
+    }
+    return registerHookCapability(update)
+  }
+
+  /**
+   * @param {string[] | undefined} modules
+   * @param {string} url
+   * @param {string} specifier
+   * @param {string | undefined} resultPath
+   * @param {string | undefined} turbopackSpecifier
+   * @returns {boolean}
+   */
+  function matchesHookCapability (modules, url, specifier, resultPath, turbopackSpecifier) {
+    if (modules === undefined || modules.includes(specifier) || modules.includes(url)) return true
+    return (turbopackSpecifier !== undefined && modules.includes(turbopackSpecifier)) ||
+      (resultPath !== undefined && modules.includes(resultPath))
+  }
+
+  /**
+   * @param {string} url
+   * @param {string} specifier
+   * @param {string | undefined} resultPath
+   * @param {string | undefined} turbopackSpecifier
+   * @returns {boolean}
+   */
+  function matchesAnyHookCapability (url, specifier, resultPath, turbopackSpecifier) {
+    if (registeredHookCapabilities === undefined) return false
+    for (const capability of registeredHookCapabilities) {
+      if (matchesHookCapability(capability.modules, url, specifier, resultPath, turbopackSpecifier)) return true
+    }
+    return false
+  }
+
+  /**
+   * @param {string} url
+   * @param {string} specifier
+   * @param {string | undefined} turbopackSpecifier
+   * @returns {ReadonlySet<string> | undefined}
+   */
+  function getReplaceExports (url, specifier, turbopackSpecifier) {
+    if (!hasExplicitHookCapabilities) return
+
+    let resultPath
+    if (url.startsWith('file:')) {
+      resultPath = fileURLToPath(url)
+    }
+
+    let matched = false
+    let replaceExports
+    for (const capability of registeredHookCapabilities) {
+      if (!matchesHookCapability(capability.modules, url, specifier, resultPath, turbopackSpecifier)) continue
+      if (capability.replaceExports === undefined) return
+
+      matched = true
+      if (replaceExports === undefined) {
+        replaceExports = capability.replaceExports
+      } else {
+        const merged = new Set(replaceExports)
+        for (const name of capability.replaceExports) merged.add(name)
+        replaceExports = merged
+      }
+    }
+    return matched ? replaceExports : undefined
+  }
+
+  if (listenForHookCapabilities !== undefined) {
+    listenForHookCapabilities(applyHookCapabilityUpdate)
+  }
 
   // Default matcher, used unless the consumer supplies its own `shouldInclude`
   // (see applyOptions). It applies the include/exclude lists, so finishResolve
@@ -378,7 +531,7 @@ export function createHook (meta) {
   // node_modules, and the full file URL for non-bare specifier imports (relative
   // paths would be error prone). An absolute path entry added via Hook over the
   // message port matches the resolved file path, so it is resolved here.
-  function defaultShouldInclude (url, specifier) {
+  function defaultShouldInclude (url, specifier, turbopackSpecifier) {
     let resultPath
     if (url.startsWith('file:')) {
       const stackTraceLimit = Error.stackTraceLimit
@@ -396,7 +549,8 @@ export function createHook (meta) {
       return each === specifier || each === url || (resultPath && each === resultPath)
     }
 
-    if (includeModules && !includeModules.some(match)) {
+    if (includeModules && !includeModules.some(match) &&
+      (!includeHookCapabilities || !matchesAnyHookCapability(url, specifier, resultPath, turbopackSpecifier))) {
       return false
     }
 
@@ -428,18 +582,12 @@ export function createHook (meta) {
     }
 
     if (data.addHookMessagePort) {
-      data.addHookMessagePort.on('message', (modules) => {
-        if (includeModules === undefined) {
-          includeModules = []
-        }
-
-        for (const each of modules) {
-          if (!each.startsWith('node:') && builtinModules.includes(each)) {
-            includeModules.push(`node:${each}`)
-          }
-
-          includeModules.push(each)
-        }
+      includeHookCapabilities = true
+      data.addHookMessagePort.on('message', (message) => {
+        const update = Array.isArray(message)
+          ? { modules: message, replaceExports: undefined }
+          : message
+        applyHookCapabilityUpdate(update)
 
         data.addHookMessagePort.postMessage('ack')
       }).unref()
@@ -492,9 +640,13 @@ export function createHook (meta) {
       return result
     }
 
-    // `shouldInclude` is always set (the include/exclude list matcher by default,
-    // a consumer-provided predicate otherwise), so no nullish check is needed.
-    if (!shouldInclude(result.url, specifier)) {
+    const turbopackSpecifier = registeredHookCapabilities === undefined
+      ? undefined
+      : getTurbopackSpecifier(specifier, result.url)
+    const included = shouldInclude === defaultShouldInclude
+      ? defaultShouldInclude(result.url, specifier, turbopackSpecifier)
+      : shouldInclude(result.url, specifier)
+    if (!included) {
       return result
     }
 
@@ -534,9 +686,13 @@ export function createHook (meta) {
     }
 
     // Preserve the format before an outer loader can normalize it.
-    const specifierData = result.format === 'module-typescript' || result.format === 'commonjs-typescript'
-      ? { specifier, format: result.format }
-      : specifier
+    const replaceExports = getReplaceExports(result.url, specifier, turbopackSpecifier)
+    let specifierData = specifier
+    if (result.format === 'module-typescript' || result.format === 'commonjs-typescript') {
+      specifierData = { specifier, format: result.format, replaceExports }
+    } else if (replaceExports !== undefined) {
+      specifierData = { specifier, replaceExports }
+    }
     specifiers.set(result.url, specifierData)
 
     return {
@@ -600,8 +756,24 @@ export function createHook (meta) {
    * @param {string} realUrl The URL of the wrapped module.
    * @param {string[] | Map<string, string | StarBinding>} bindings Its exported bindings.
    * @param {string} originalSpecifier The specifier used to import the module.
+   * @param {ReadonlySet<string> | undefined} replaceExports Export bindings hooks can replace.
+   * @param {LoadContext['format']} format The wrapped module format.
    */
-  function buildWrapperSource (realUrl, bindings, originalSpecifier) {
+  function buildWrapperSource (realUrl, bindings, originalSpecifier, replaceExports, format) {
+    const isEsm = format === 'module' || format === 'module-typescript'
+    if (isEsm && replaceExports?.size === 0 && shouldReexport('module.exports', realUrl)) {
+      const hasDefault = bindings instanceof Map ? bindings.has('default') : bindings.includes('default')
+      return `
+import { register, ModuleBinder } from ${JSON.stringify(iitmURL)}
+import * as namespace from ${JSON.stringify(realUrl)}
+export * from ${JSON.stringify(realUrl)}
+${hasDefault ? `export { default } from ${JSON.stringify(realUrl)}\n` : ''}
+const __binder = ModuleBinder.readOnly(namespace)
+
+register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifier)})
+`
+    }
+
     // The wrapped module imports its namespace as `namespace`, which serves
     // every export but the ones a same-origin `export *` collision forced onto
     // their defining module (#171): the aggregate namespace drops those as
@@ -613,13 +785,23 @@ export function createHook (meta) {
     let bindingNames = ''
     let bindingSources
     let exportSpecifiers = ''
+    let passthroughNames = ''
+    let passthroughExportGroups
+    let passthroughImportSpecifiers = ''
+    let passthroughExportSpecifiers = ''
+    let passthroughReadCases = ''
+    let passthroughSources
+    let passthroughIndex = 0
     let writeCases = ''
     let index = 0
+    let canUseImportedBindings = replaceExports !== undefined
     for (const binding of bindings.values()) {
       const directName = typeof binding === 'string' ? binding : undefined
       const name = directName ?? binding.name
       let namespaceName = 'namespace'
+      let sourceSpecifier = realUrl
       if (directName === undefined) {
+        canUseImportedBindings = false
         originNamespaces ??= new Map()
         namespaceName = originNamespaces.get(binding.origin)
         if (namespaceName === undefined) {
@@ -627,9 +809,45 @@ export function createHook (meta) {
           originNamespaces.set(binding.origin, namespaceName)
           originImports += `import * as ${namespaceName} from ${JSON.stringify(binding.origin)}\n`
         }
+        sourceSpecifier = binding.origin
       }
-      const variableName = `$${index}`
       const objectKey = JSON.stringify(name)
+      const exportName = name === 'default' ? name : objectKey
+      if (replaceExports !== undefined && !replaceExports.has(name)) {
+        const passthroughVariableName = `$p${passthroughIndex}`
+        if (name === 'module.exports') {
+          canUseImportedBindings = false
+        } else {
+          passthroughImportSpecifiers += passthroughImportSpecifiers === ''
+            ? `${exportName} as ${passthroughVariableName}`
+            : `, ${exportName} as ${passthroughVariableName}`
+          passthroughExportSpecifiers += passthroughExportSpecifiers === ''
+            ? `${passthroughVariableName} as ${exportName}`
+            : `, ${passthroughVariableName} as ${exportName}`
+          passthroughReadCases += `    case ${passthroughIndex}: return ${passthroughVariableName}\n`
+        }
+        passthroughNames += passthroughNames === '' ? objectKey : `, ${objectKey}`
+        if (passthroughSources !== undefined) passthroughSources += ', '
+        if (namespaceName !== 'namespace') {
+          passthroughSources ??= 'undefined, '.repeat(passthroughIndex)
+          passthroughSources += namespaceName
+        } else if (passthroughSources !== undefined) {
+          passthroughSources += 'undefined'
+        }
+        passthroughIndex++
+        if (shouldReexport(name, realUrl)) {
+          passthroughExportGroups ??= new Map()
+          const exportNames = passthroughExportGroups.get(sourceSpecifier)
+          passthroughExportGroups.set(
+            sourceSpecifier,
+            exportNames === undefined ? exportName : `${exportNames}, ${exportName}`
+          )
+        }
+        continue
+      }
+
+      canUseImportedBindings = false
+      const variableName = `$${index}`
       declarationNames += declarationNames === '' ? variableName : `, ${variableName}`
       bindingNames += bindingNames === '' ? objectKey : `, ${objectKey}`
       if (bindingSources !== undefined) bindingSources += ', '
@@ -641,14 +859,33 @@ export function createHook (meta) {
       }
       writeCases += `    case ${index++}: ${variableName} = value; break\n`
       if (shouldReexport(name, realUrl)) {
-        const exportName = name === 'default' ? name : objectKey
         exportSpecifiers += exportSpecifiers === ''
           ? `${variableName} as ${exportName}`
           : `, ${variableName} as ${exportName}`
       }
     }
+    const passthroughSourceArguments = passthroughSources === undefined ? '' : `, [${passthroughSources}]`
+    let passthroughReexports = ''
+    if (passthroughExportGroups !== undefined) {
+      for (const [sourceSpecifier, exportNames] of passthroughExportGroups) {
+        passthroughReexports += `export { ${exportNames} } from ${JSON.stringify(sourceSpecifier)}\n`
+      }
+    }
+    const useImportedBindings = canUseImportedBindings && passthroughNames !== ''
+    const moduleImport = useImportedBindings
+      ? `import { ${passthroughImportSpecifiers} } from ${JSON.stringify(realUrl)}`
+      : `import * as namespace from ${JSON.stringify(realUrl)}`
     const binder = declarationNames === ''
-      ? 'const __binder = new ModuleBinder(namespace)\n'
+      ? passthroughNames === ''
+        ? 'const __binder = new ModuleBinder(namespace)\n'
+        : useImportedBindings
+          ? `function __read (index) {
+  switch (index) {
+${passthroughReadCases}  }
+}
+const __binder = new ModuleBinder(undefined, undefined, undefined, undefined, [${passthroughNames}], undefined, __read)
+`
+          : `const __binder = new ModuleBinder(namespace, undefined, undefined, undefined, [${passthroughNames}]${passthroughSourceArguments})\n`
       : `let ${declarationNames}
 function __write (index, value) {
   switch (index) {
@@ -656,16 +893,22 @@ ${writeCases}  }
 }
 const __binder = new ModuleBinder(namespace, [${bindingNames}], __write${bindingSources === undefined
   ? ''
-  : `, [${bindingSources}]`})
+  : `, [${bindingSources}]`}${passthroughNames === ''
+  ? ''
+  : `${bindingSources === undefined ? ', undefined' : ''}, [${passthroughNames}]${passthroughSourceArguments}`})
 `
     const reexports = exportSpecifiers === '' ? '' : `export { ${exportSpecifiers} }\n`
+    if (useImportedBindings) {
+      passthroughReexports = `export { ${passthroughExportSpecifiers} }\n`
+    }
 
     return `
 import { register, ModuleBinder } from ${JSON.stringify(iitmURL)}
-import * as namespace from ${JSON.stringify(realUrl)}
+${moduleImport}
 ${originImports}
 ${binder}
 ${reexports}
+${passthroughReexports}
 
 __binder.flush()
 
@@ -680,14 +923,15 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
    * @param {LoadContext} context Its loader context.
    * @param {string} originalSpecifier The original import specifier.
    * @param {string[] | Map<string, string | StarBinding>} bindings Its exported bindings.
+   * @param {ReadonlySet<string> | undefined} replaceExports Export bindings hooks can replace.
    */
-  function onWrapSuccess (realUrl, context, originalSpecifier, bindings) {
+  function onWrapSuccess (realUrl, context, originalSpecifier, bindings, replaceExports) {
     specifiers.delete(realUrl)
     // context.format is set to 'commonjs' by getCjsExports during processModule.
     if (context.format === 'commonjs') {
       cjsInIitmChain.add(realUrl)
     }
-    return buildWrapperSource(realUrl, bindings, originalSpecifier)
+    return buildWrapperSource(realUrl, bindings, originalSpecifier, replaceExports, context.format)
   }
 
   // Bookkeeping shared by the async and sync wrap paths when `processModule`
@@ -722,9 +966,13 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
 
       let originalSpecifier = specifierData
       let processContext = context
+      let replaceExports
       if (typeof specifierData !== 'string') {
         originalSpecifier = specifierData.specifier
-        processContext = { ...context, format: specifierData.format }
+        replaceExports = specifierData.replaceExports
+        if (specifierData.format !== undefined) {
+          processContext = { ...context, format: specifierData.format }
+        }
       }
 
       try {
@@ -732,7 +980,7 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: parentGetSource }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings) }
+        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings, replaceExports) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         // Revert back to the non-iitm URL
@@ -762,9 +1010,13 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
 
       let originalSpecifier = specifierData
       let processContext = context
+      let replaceExports
       if (typeof specifierData !== 'string') {
         originalSpecifier = specifierData.specifier
-        processContext = { ...context, format: specifierData.format }
+        replaceExports = specifierData.replaceExports
+        if (specifierData.format !== undefined) {
+          processContext = { ...context, format: specifierData.format }
+        }
       }
 
       try {
@@ -772,7 +1024,7 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: nextLoad }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings) }
+        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings, replaceExports) }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         url = realUrl

--- a/create-hook.mjs
+++ b/create-hook.mjs
@@ -61,6 +61,7 @@ const TRACE_WARNINGS = process.execArgv.includes('--trace-warnings')
  * @typedef {object} ProcessResult
  * @property {string[] | Map<string, string | StarBinding>} bindings
  * @property {Map<string, string> | undefined} origins
+ * @property {ReadonlySet<string>} [nonEnumerableExportNames]
  */
 
 function hasIitm (url) {
@@ -248,13 +249,13 @@ function shouldExcludeExport (name, sourceUrl) {
  * for a module with no `export *`.
  */
 function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, seen }) {
-  const { exportNames, starReexports } = yield * getExports(srcUrl, context)
+  const { exportNames, nonEnumerableExportNames, starReexports } = yield * getExports(srcUrl, context)
 
   // Most modules have no export star. Keep that path array-backed so it pays
   // neither merge bookkeeping nor a Map lookup for each direct export.
   if (starReexports === undefined) {
     if (!excludeDefault) {
-      return { bindings: exportNames, origins: undefined }
+      return { bindings: exportNames, origins: undefined, nonEnumerableExportNames }
     }
 
     const bindings = []
@@ -262,7 +263,7 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
       if (shouldExcludeExport(name, srcUrl)) continue
       bindings.push(name)
     }
-    return { bindings, origins: undefined }
+    return { bindings, origins: undefined, nonEnumerableExportNames }
   }
 
   const bindings = new Map()
@@ -365,7 +366,7 @@ function * processModule ({ srcUrl, context, excludeDefault = false, depth = 0, 
 }
 
 function addIitm (url) {
-  const urlObj = new URL(url)
+  const urlObj = new URL(url.startsWith('node:') ? `file:///${url}` : url)
   urlObj.searchParams.set('iitm', 'true')
   return urlObj.href
 }
@@ -640,6 +641,11 @@ export function createHook (meta, listenForHookCapabilities) {
       return result
     }
 
+    // A co-resident IITM loader owns an already-wrapped builtin URL.
+    if (result.url.startsWith('file:///node:') && hasIitm(result.url)) {
+      return result
+    }
+
     const turbopackSpecifier = registeredHookCapabilities === undefined
       ? undefined
       : getTurbopackSpecifier(specifier, result.url)
@@ -758,9 +764,18 @@ export function createHook (meta, listenForHookCapabilities) {
    * @param {string} originalSpecifier The specifier used to import the module.
    * @param {ReadonlySet<string> | undefined} replaceExports Export bindings hooks can replace.
    * @param {LoadContext['format']} format The wrapped module format.
+   * @param {ReadonlySet<string> | undefined} nonEnumerableExportNames Non-enumerable builtin exports.
    */
-  function buildWrapperSource (realUrl, bindings, originalSpecifier, replaceExports, format) {
+  function buildWrapperSource (
+    realUrl,
+    bindings,
+    originalSpecifier,
+    replaceExports,
+    format,
+    nonEnumerableExportNames
+  ) {
     const isEsm = format === 'module' || format === 'module-typescript'
+    const isBuiltin = format === 'builtin'
     if (isEsm && replaceExports?.size === 0 && shouldReexport('module.exports', realUrl)) {
       const hasDefault = bindings instanceof Map ? bindings.has('default') : bindings.includes('default')
       return `
@@ -785,6 +800,7 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
     let bindingNames = ''
     let bindingSources
     let exportSpecifiers = ''
+    let passthroughDeclarations = ''
     let passthroughNames = ''
     let passthroughExportGroups
     let passthroughImportSpecifiers = ''
@@ -794,7 +810,7 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
     let passthroughIndex = 0
     let writeCases = ''
     let index = 0
-    let canUseImportedBindings = replaceExports !== undefined
+    let canUseImportedBindings = isEsm && replaceExports !== undefined
     for (const binding of bindings.values()) {
       const directName = typeof binding === 'string' ? binding : undefined
       const name = directName ?? binding.name
@@ -813,11 +829,12 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
       }
       const objectKey = JSON.stringify(name)
       const exportName = name === 'default' ? name : objectKey
+      const sourceName = isBuiltin && nonEnumerableExportNames?.has(name) ? `${namespaceName}.default` : namespaceName
       if (replaceExports !== undefined && !replaceExports.has(name)) {
-        const passthroughVariableName = `$p${passthroughIndex}`
         if (name === 'module.exports') {
           canUseImportedBindings = false
-        } else {
+        } else if (isEsm) {
+          const passthroughVariableName = `$p${passthroughIndex}`
           passthroughImportSpecifiers += passthroughImportSpecifiers === ''
             ? `${exportName} as ${passthroughVariableName}`
             : `, ${exportName} as ${passthroughVariableName}`
@@ -825,17 +842,23 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
             ? `${passthroughVariableName} as ${exportName}`
             : `, ${passthroughVariableName} as ${exportName}`
           passthroughReadCases += `    case ${passthroughIndex}: return ${passthroughVariableName}\n`
+        } else if (!isBuiltin || sourceName !== namespaceName) {
+          const passthroughVariableName = `$p${passthroughIndex}`
+          passthroughDeclarations += `const ${passthroughVariableName} = ${sourceName}[${objectKey}]\n`
+          passthroughExportSpecifiers += passthroughExportSpecifiers === ''
+            ? `${passthroughVariableName} as ${exportName}`
+            : `, ${passthroughVariableName} as ${exportName}`
         }
         passthroughNames += passthroughNames === '' ? objectKey : `, ${objectKey}`
         if (passthroughSources !== undefined) passthroughSources += ', '
-        if (namespaceName !== 'namespace') {
+        if (sourceName !== 'namespace') {
           passthroughSources ??= 'undefined, '.repeat(passthroughIndex)
-          passthroughSources += namespaceName
+          passthroughSources += sourceName
         } else if (passthroughSources !== undefined) {
           passthroughSources += 'undefined'
         }
         passthroughIndex++
-        if (shouldReexport(name, realUrl)) {
+        if (isEsm && shouldReexport(name, realUrl)) {
           passthroughExportGroups ??= new Map()
           const exportNames = passthroughExportGroups.get(sourceSpecifier)
           passthroughExportGroups.set(
@@ -851,9 +874,9 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
       declarationNames += declarationNames === '' ? variableName : `, ${variableName}`
       bindingNames += bindingNames === '' ? objectKey : `, ${objectKey}`
       if (bindingSources !== undefined) bindingSources += ', '
-      if (namespaceName !== 'namespace') {
+      if (sourceName !== 'namespace') {
         bindingSources ??= 'undefined, '.repeat(index)
-        bindingSources += namespaceName
+        bindingSources += sourceName
       } else if (bindingSources !== undefined) {
         bindingSources += 'undefined'
       }
@@ -898,7 +921,14 @@ const __binder = new ModuleBinder(namespace, [${bindingNames}], __write${binding
   : `${bindingSources === undefined ? ', undefined' : ''}, [${passthroughNames}]${passthroughSourceArguments}`})
 `
     const reexports = exportSpecifiers === '' ? '' : `export { ${exportSpecifiers} }\n`
+    const builtinReexports = isBuiltin
+      ? `export * from ${JSON.stringify(realUrl)}\n${replaceExports !== undefined && !replaceExports.has('default')
+          ? `export { default } from ${JSON.stringify(realUrl)}\n`
+          : ''}`
+      : ''
     if (useImportedBindings) {
+      passthroughReexports = `export { ${passthroughExportSpecifiers} }\n`
+    } else if (!isEsm && passthroughExportSpecifiers !== '') {
       passthroughReexports = `export { ${passthroughExportSpecifiers} }\n`
     }
 
@@ -906,8 +936,10 @@ const __binder = new ModuleBinder(namespace, [${bindingNames}], __write${binding
 import { register, ModuleBinder } from ${JSON.stringify(iitmURL)}
 ${moduleImport}
 ${originImports}
+${passthroughDeclarations}
 ${binder}
 ${reexports}
+${builtinReexports}
 ${passthroughReexports}
 
 __binder.flush()
@@ -924,14 +956,29 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
    * @param {string} originalSpecifier The original import specifier.
    * @param {string[] | Map<string, string | StarBinding>} bindings Its exported bindings.
    * @param {ReadonlySet<string> | undefined} replaceExports Export bindings hooks can replace.
+   * @param {ReadonlySet<string> | undefined} nonEnumerableExportNames Non-enumerable builtin exports.
    */
-  function onWrapSuccess (realUrl, context, originalSpecifier, bindings, replaceExports) {
+  function onWrapSuccess (
+    realUrl,
+    context,
+    originalSpecifier,
+    bindings,
+    replaceExports,
+    nonEnumerableExportNames
+  ) {
     specifiers.delete(realUrl)
     // context.format is set to 'commonjs' by getCjsExports during processModule.
     if (context.format === 'commonjs') {
       cjsInIitmChain.add(realUrl)
     }
-    return buildWrapperSource(realUrl, bindings, originalSpecifier, replaceExports, context.format)
+    return buildWrapperSource(
+      realUrl,
+      bindings,
+      originalSpecifier,
+      replaceExports,
+      context.format,
+      nonEnumerableExportNames
+    )
   }
 
   // Bookkeeping shared by the async and sync wrap paths when `processModule`
@@ -976,11 +1023,20 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
       }
 
       try {
-        const { bindings } = await driveAsync(
+        const { bindings, nonEnumerableExportNames } = await driveAsync(
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: parentGetSource }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings, replaceExports) }
+        return {
+          source: onWrapSuccess(
+            realUrl,
+            processContext,
+            originalSpecifier,
+            bindings,
+            replaceExports,
+            nonEnumerableExportNames
+          )
+        }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         // Revert back to the non-iitm URL
@@ -1020,11 +1076,20 @@ register(${JSON.stringify(realUrl)}, __binder, ${JSON.stringify(originalSpecifie
       }
 
       try {
-        const { bindings } = driveSync(
+        const { bindings, nonEnumerableExportNames } = driveSync(
           processModule({ srcUrl: realUrl, context: processContext }),
           { resolve: cachedResolve, load: nextLoad }
         )
-        return { source: onWrapSuccess(realUrl, processContext, originalSpecifier, bindings, replaceExports) }
+        return {
+          source: onWrapSuccess(
+            realUrl,
+            processContext,
+            originalSpecifier,
+            bindings,
+            replaceExports,
+            nonEnumerableExportNames
+          )
+        }
       } catch (cause) {
         onWrapFailure(realUrl, cause)
         url = realUrl

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,12 @@ export type HookFn = (exported: Namespace, name: string, baseDir: string|void) =
 
 export type Options = {
   internals?: boolean
+
+  /**
+   * Export bindings that the hook can replace. Bindings not in this list keep
+   * their original live bindings. Use an empty list for nested mutations only.
+   */
+  replaceExports?: ReadonlyArray<string>
 }
 
 export declare class Hook {
@@ -39,6 +45,8 @@ export declare class Hook {
    * `{ internals: false }`. If internals is true, then the hook will operate
    * on internal modules of packages in node_modules. Otherwise it will not,
    * unless they are mentioned specifically in the modules array.
+   * `replaceExports` declares the export bindings that the hook can replace.
+   * Other bindings retain their source module's live binding.
    * @param {HookFunction} hookFn The function to be run on each module.
    */
   constructor (modules: Array<string>, options: Options, hookFn: HookFn)

--- a/index.js
+++ b/index.js
@@ -14,39 +14,73 @@ if (!isBuiltin) {
 
 const {
   importHooks,
+  registerHookCapability,
+  removeHookCapability,
+  replayHookCapabilities,
   specifiers,
   toHook
 } = require('./lib/register')
+const getTurbopackSpecifier = require('./lib/turbopack')
 
 /**
- * Checks turbopack specifiers separately (for Next.js 16+).
- *
- * If turbopack is used, specifiers will have an additional hash appended to the end.
- * Something like "ai" might become "ai-5e7181a616786b24". This only happens in Next.js 16+.
- * Just checking if the baseDir ends with this new specifier won't match, as the baseDir still has the plain package.
- *
- * This logic isolates a new check for checking the actual name in the case turbopack is being used.
- *
- * @param specifier {string}
- * @param baseDir {string}
+ * @typedef {object} HookCapability
+ * @property {number} id
+ * @property {string[] | undefined} modules
+ * @property {ReadonlyArray<string> | undefined} replaceExports
+ */
+/** @typedef {{ id: number, removed: true }} HookCapabilityRemoval */
+/** @type {WeakMap<Function, HookCapability[]>} */
+const hookCapabilities = new WeakMap()
+
+/**
+ * @param {string} specifier
+ * @param {string} baseDir
+ * @returns {boolean}
  */
 function isTurbopackSpecifier (specifier, baseDir) {
-  const usingTurbopack = process.env.TURBOPACK ?? process.argv.includes('--turbo')
-  if (!usingTurbopack) return false
-
-  const specifierWithoutTurbopackHash = specifier.slice(0, specifier.lastIndexOf('-'))
-  return baseDir.endsWith(specifierWithoutTurbopackHash)
+  const turbopackSpecifier = getTurbopackSpecifier(specifier)
+  return turbopackSpecifier !== undefined && baseDir.endsWith(turbopackSpecifier)
 }
 
-function addHook (hook) {
+/**
+ * @param {(name: string, namespace: object, specifier: string) => void} hook
+ * @param {HookCapability} capability
+ */
+function addHookInternal (hook, capability) {
   importHooks.push(hook)
-  toHook.forEach(([name, namespace, specifier]) => hook(name, namespace, specifier))
+  const capabilities = hookCapabilities.get(hook)
+  if (capabilities === undefined) {
+    hookCapabilities.set(hook, [capability])
+  } else {
+    capabilities.push(capability)
+  }
+  try {
+    toHook.forEach(([name, namespace, specifier]) => hook(name, namespace, specifier))
+  } catch (error) {
+    removeHook(hook)
+    throw error
+  }
+}
+
+/**
+ * @param {(name: string, namespace: object, specifier: string) => void} hook
+ * @returns {void}
+ */
+function addHook (hook) {
+  const capability = registerHookCapability(undefined, undefined)
+  sendHookCapabilityToLoader(capability)
+  addHookInternal(hook, capability)
 }
 
 function removeHook (hook) {
   const index = importHooks.indexOf(hook)
   if (index > -1) {
     importHooks.splice(index, 1)
+    const capabilities = hookCapabilities.get(hook)
+    const capability = capabilities.shift()
+    if (capabilities.length === 0) hookCapabilities.delete(hook)
+    const removal = removeHookCapability(capability)
+    sendHookCapabilityToLoader(removal)
   }
 }
 
@@ -63,6 +97,32 @@ function callHookFn (hookFn, namespace, name, baseDir) {
 }
 
 let sendModulesToLoader
+
+/**
+ * @param {HookCapability | HookCapabilityRemoval} update
+ */
+function sendHookCapabilityToLoader (update) {
+  if (!sendModulesToLoader) return
+  sendModulesToLoader(update)
+}
+
+/**
+ * @param {object | null} options
+ * @returns {ReadonlyArray<string> | undefined}
+ */
+function getReplaceExports (options) {
+  const replaceExports = options?.replaceExports
+  if (replaceExports === undefined) return
+  if (!Array.isArray(replaceExports)) {
+    throw new TypeError("The 'replaceExports' option must be an array of export names")
+  }
+  for (let index = 0; index < replaceExports.length; index++) {
+    if (typeof replaceExports[index] !== 'string') {
+      throw new TypeError("The 'replaceExports' option must be an array of export names")
+    }
+  }
+  return replaceExports.slice()
+}
 
 /**
  * EXPERIMENTAL
@@ -128,6 +188,8 @@ function createAddHookMessageChannel () {
   const addHookMessagePort = port2
   const registerOptions = { data: { addHookMessagePort, include: [] }, transferList: [addHookMessagePort] }
 
+  replayHookCapabilities(sendHookCapabilityToLoader)
+
   return { registerOptions, addHookMessagePort, waitForAllMessagesAcknowledged }
 }
 
@@ -142,10 +204,14 @@ function Hook (modules, options, hookFn) {
     options = null
   }
   const internals = options ? options.internals === true : false
+  const replaceExports = getReplaceExports(options)
 
-  if (sendModulesToLoader && Array.isArray(modules)) {
-    sendModulesToLoader(modules)
+  if (internals && replaceExports !== undefined) {
+    throw new Error("The 'replaceExports' option is incompatible with the 'internals' option")
   }
+
+  const capability = registerHookCapability(Array.isArray(modules) ? modules : undefined, replaceExports)
+  sendHookCapabilityToLoader(capability)
 
   this._iitmHook = (name, namespace, specifier) => {
     const loadUrl = name
@@ -207,7 +273,7 @@ function Hook (modules, options, hookFn) {
     }
   }
 
-  addHook(this._iitmHook)
+  addHookInternal(this._iitmHook, capability)
 }
 
 Hook.prototype.unhook = function () {

--- a/lib/get-exports.mjs
+++ b/lib/get-exports.mjs
@@ -12,7 +12,17 @@ const nodeMajor = Number(process.versions.node.split('.')[0])
 export const hasModuleExportsCJSDefault = nodeMajor >= 23
 
 /** @typedef {{ specifier: string, parentURL: string }} StarReexport */
-/** @typedef {{ exportNames: Iterable<string>, starReexports?: StarReexport[] }} ModuleExports */
+/**
+ * @typedef {object} ModuleExports
+ * @property {Iterable<string>} exportNames
+ * @property {ReadonlySet<string>} [nonEnumerableExportNames]
+ * @property {StarReexport[]} [starReexports]
+ */
+/**
+ * @typedef {object} BuiltinExports
+ * @property {Set<string>} exportNames
+ * @property {Set<string>} nonEnumerableExportNames
+ */
 
 let parserInitialized = false
 let stripTypeScriptTypes
@@ -36,6 +46,7 @@ function addDefault (exportNames) {
 }
 
 // Cached exports for Node built-in modules
+/** @type {Map<string, BuiltinExports>} */
 const BUILT_INS = new Map()
 
 let require
@@ -57,16 +68,28 @@ function loadBuiltin (name) {
   return require(name)
 }
 
+/**
+ * @param {string} name The builtin module name.
+ * @returns {BuiltinExports}
+ */
 function getExportsForNodeBuiltIn (name) {
   let exports = BUILT_INS.get(name)
 
   if (!exports) {
+    const builtin = loadBuiltin(name)
     // get all properties both enumerable and non-enumerable
-    exports = addDefault(Object.getOwnPropertyNames(loadBuiltin(name)))
+    const exportNames = addDefault(Object.getOwnPropertyNames(builtin))
+    const nonEnumerableExportNames = new Set()
+    for (const exportName of exportNames) {
+      if (Object.getOwnPropertyDescriptor(builtin, exportName)?.enumerable === false) {
+        nonEnumerableExportNames.add(exportName)
+      }
+    }
     // added in node 23 as alias for default in cjs modules
     if (hasModuleExportsCJSDefault) {
-      exports.add('module.exports')
+      exportNames.add('module.exports')
     }
+    exports = { exportNames, nonEnumerableExportNames }
     BUILT_INS.set(name, exports)
   }
 
@@ -169,7 +192,7 @@ function * getCjsExports (url, context, source) {
 
     for (const reexport of result.reexports) {
       if (reexport.startsWith('node:') || builtinModules.includes(reexport)) {
-        for (const each of getExportsForNodeBuiltIn(reexport)) {
+        for (const each of getExportsForNodeBuiltIn(reexport).exportNames) {
           full.add(each)
         }
         continue
@@ -276,7 +299,7 @@ export function * getExports (url, context) {
     if (format === 'builtin') {
       // Builtins don't give us the source property, so we're stuck
       // just requiring it to get the exports.
-      return { exportNames: getExportsForNodeBuiltIn(url) }
+      return getExportsForNodeBuiltIn(url)
     }
 
     // Sometimes source is retrieved by parentLoad, CommonJs isn't.

--- a/lib/register.js
+++ b/lib/register.js
@@ -6,6 +6,69 @@ const importHooks = [] // TODO should this be a Set?
 const binders = new WeakMap()
 const specifiers = new Map()
 const toHook = []
+/**
+ * @typedef {object} HookCapability
+ * @property {number} id Capability identity.
+ * @property {string[] | undefined} modules Modules matched by the hook, or all modules when omitted.
+ * @property {ReadonlyArray<string> | undefined} replaceExports Export bindings the hook can replace.
+ */
+/** @typedef {{ id: number, removed: true }} HookCapabilityRemoval */
+/** @type {Map<number, HookCapability>} */
+const capabilities = new Map()
+/** @type {Set<(update: HookCapability | HookCapabilityRemoval) => void>} */
+const capabilityListeners = new Set()
+let nextCapabilityId = 0
+
+/**
+ * @param {HookCapability | HookCapabilityRemoval} update
+ */
+function publishHookCapability (update) {
+  for (const listener of capabilityListeners) {
+    listener(update)
+  }
+}
+
+/**
+ * @param {string[] | undefined} modules
+ * @param {ReadonlyArray<string> | undefined} replaceExports
+ * @returns {HookCapability}
+ */
+function registerHookCapability (modules, replaceExports) {
+  const capability = { id: nextCapabilityId++, modules, replaceExports }
+  capabilities.set(capability.id, capability)
+  publishHookCapability(capability)
+  return capability
+}
+
+/**
+ * @param {HookCapability} capability
+ * @returns {HookCapabilityRemoval}
+ */
+function removeHookCapability (capability) {
+  capabilities.delete(capability.id)
+  const removal = { id: capability.id, removed: true }
+  publishHookCapability(removal)
+  return removal
+}
+
+/**
+ * @param {(update: HookCapability | HookCapabilityRemoval) => void} listener
+ * @returns {void}
+ */
+function replayHookCapabilities (listener) {
+  for (const capability of capabilities.values()) {
+    listener(capability)
+  }
+}
+
+/**
+ * @param {(update: HookCapability | HookCapabilityRemoval) => void} listener
+ * @returns {void}
+ */
+function listenForHookCapabilities (listener) {
+  replayHookCapabilities(listener)
+  capabilityListeners.add(listener)
+}
 
 /**
  * @param {object} source The module namespace.
@@ -60,6 +123,7 @@ function register (name, binder, specifier) {
 // then at these intervals; unref'd so best-effort retries never hold the process
 // open. Frozen once at module load rather than rebuilt per wrapper.
 const RETRY_DELAYS = [0, 10, 50]
+const READ_ONLY = Symbol('readOnly')
 
 /**
  * Per-wrapped-module state a generated wrapper builds once to expose its exports
@@ -73,25 +137,91 @@ const RETRY_DELAYS = [0, 10, 50]
  */
 class ModuleBinder {
   // Mimics a Module namespace object (https://tc39.es/ecma262/#sec-module-namespace-objects).
-  namespace = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })
-  #set = Object.create(null)
+  namespace
+  #set
   #write
   #overridden
   #pending
+  #readOnly
 
   /**
    * @param {object} source The wrapped module namespace.
-   * @param {string[]} [keys] Export names in wrapper-binding order.
+   * @returns {ModuleBinder}
+   */
+  static readOnly (source) {
+    return new ModuleBinder(source, READ_ONLY)
+  }
+
+  /**
+   * @param {object | undefined} source The wrapped module namespace.
+   * @param {string[] | symbol} [keys] Export names in wrapper-binding order, or the read-only marker.
    * @param {(index: number, value: unknown) => void} [write] Assigns a wrapper binding by index.
    * @param {object[]} [sources] Alternate namespaces for star-collision bindings.
+   * @param {string[]} [passthroughKeys] Read-only export names.
+   * @param {object[]} [passthroughSources] Alternate namespaces for read-only bindings.
+   * @param {(index: number) => unknown} [read] Reads a live imported binding by index.
    */
-  constructor (source, keys, write, sources) {
+  constructor (source, keys, write, sources, passthroughKeys, passthroughSources, read) {
+    if (keys === READ_ONLY) {
+      this.namespace = source
+      this.#readOnly = true
+      return
+    }
+    this.namespace = Object.create(null, { [Symbol.toStringTag]: { value: 'Module' } })
+    this.#set = Object.create(null)
     this.#write = write
+    if (read !== undefined) {
+      const indexes = this.#set
+      for (let index = 0; index < passthroughKeys.length; index++) {
+        indexes[passthroughKeys[index]] = ~index
+        this.namespace[passthroughKeys[index]] = undefined
+      }
+      this.namespace = new Proxy(this.namespace, {
+        /**
+         * @param {object} target
+         * @param {string | symbol} key
+         * @returns {unknown}
+         */
+        get (target, key) {
+          const index = indexes[key]
+          return index < 0 ? read(~index) : target[key]
+        },
+        /**
+         * @param {object} target
+         * @param {string | symbol} key
+         * @returns {PropertyDescriptor | undefined}
+         */
+        getOwnPropertyDescriptor (target, key) {
+          const descriptor = Object.getOwnPropertyDescriptor(target, key)
+          const index = indexes[key]
+          if (descriptor !== undefined && index < 0) descriptor.value = read(~index)
+          return descriptor
+        }
+      })
+      return
+    }
     if (keys !== undefined) {
       for (let index = 0; index < keys.length; index++) {
         this.#bind(keys[index], index, sources?.[index] ?? source)
       }
     }
+    if (passthroughKeys !== undefined) {
+      for (let index = 0; index < passthroughKeys.length; index++) {
+        this.#bindReadOnly(passthroughKeys[index], passthroughSources?.[index] ?? source)
+      }
+    }
+  }
+
+  /**
+   * @param {string} key The export name.
+   * @param {object} source The binding's source namespace.
+   * @returns {void}
+   */
+  #bindReadOnly (key, source) {
+    Object.defineProperty(this.namespace, key, {
+      enumerable: true,
+      get: () => readExport(source, key)
+    })
   }
 
   /**
@@ -125,8 +255,10 @@ class ModuleBinder {
    * @returns {boolean}
    */
   write (key, value) {
-    const index = this.#set[key]
-    if (index !== undefined) {
+    const index = this.#readOnly ? -1 : this.#set[key]
+    if (index < 0) {
+      throw new TypeError(`Cannot replace export ${String(key)} because it is not listed in 'replaceExports'`)
+    } else if (index !== undefined) {
       this.#write(index, value)
       if (this.#pending !== undefined) {
         this.#overridden ??= Object.create(null)
@@ -215,5 +347,9 @@ class ModuleBinder {
 exports.register = register
 exports.ModuleBinder = ModuleBinder
 exports.importHooks = importHooks
+exports.listenForHookCapabilities = listenForHookCapabilities
+exports.registerHookCapability = registerHookCapability
+exports.removeHookCapability = removeHookCapability
+exports.replayHookCapabilities = replayHookCapabilities
 exports.specifiers = specifiers
 exports.toHook = toHook

--- a/lib/turbopack.js
+++ b/lib/turbopack.js
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+const NODE_MODULES_PATH = '/node_modules/'
+
+/**
+ * @param {string} specifier
+ * @param {string} [url]
+ * @returns {string | undefined}
+ */
+function getTurbopackSpecifier (specifier, url) {
+  const usingTurbopack = process.env.TURBOPACK ?? process.argv.includes('--turbo')
+  if (!usingTurbopack) return
+
+  const hashSeparator = specifier.lastIndexOf('-')
+  if (hashSeparator === -1) return
+  const result = specifier.slice(0, hashSeparator)
+  if (url === undefined || url === `node:${result}`) return result
+
+  const nodeModulesIndex = url.lastIndexOf(NODE_MODULES_PATH)
+  if (nodeModulesIndex === -1) return
+  const packageStart = nodeModulesIndex + NODE_MODULES_PATH.length
+  let packageEnd = url.indexOf('/', packageStart)
+  if (url[packageStart] === '@') packageEnd = url.indexOf('/', packageEnd + 1)
+  if (packageEnd === -1) packageEnd = url.length
+  if (url.slice(packageStart, packageEnd) === result) return result
+}
+
+module.exports = getTurbopackSpecifier

--- a/register-hooks.mjs
+++ b/register-hooks.mjs
@@ -1,10 +1,11 @@
 import * as module from 'module'
 import { createHook } from './create-hook.mjs'
+import hookRegistry from './lib/register.js'
 import { supportsSyncHooks } from './supports-sync-hooks.mjs'
 
 export { supportsSyncHooks }
 
-const hook = createHook(import.meta)
+const hook = createHook(import.meta, hookRegistry.listenForHookCapabilities)
 
 let registered = false
 

--- a/test/fixtures/export-capability-default.mjs
+++ b/test/fixtures/export-capability-default.mjs
@@ -1,0 +1,1 @@
+export default function original () {}

--- a/test/fixtures/export-capability-legacy.mjs
+++ b/test/fixtures/export-capability-legacy.mjs
@@ -1,0 +1,1 @@
+export const value = 'original'

--- a/test/fixtures/export-capability-live-consumer.mjs
+++ b/test/fixtures/export-capability-live-consumer.mjs
@@ -1,0 +1,7 @@
+import { Alias, Late, init, state } from './export-capability-live.mjs'
+
+init()
+
+export class Sub extends Late {}
+export class AliasSub extends Alias {}
+export { state }

--- a/test/fixtures/export-capability-live.mjs
+++ b/test/fixtures/export-capability-live.mjs
@@ -1,0 +1,8 @@
+export const state = { hookCount: 0 }
+export let Late
+
+export function init () {
+  Late = class Late {}
+}
+
+export { Late as Alias }

--- a/test/fixtures/export-capability-named.mjs
+++ b/test/fixtures/export-capability-named.mjs
@@ -1,0 +1,4 @@
+export const state = { hooked: false }
+export const untouched = 'original'
+export const first = 'original first'
+export const second = 'original second'

--- a/test/fixtures/typescript-normalized-format-register-hooks.mjs
+++ b/test/fixtures/typescript-normalized-format-register-hooks.mjs
@@ -1,5 +1,6 @@
 import { deepStrictEqual, ok, strictEqual } from 'node:assert/strict'
 import { registerHooks } from 'node:module'
+import { fileURLToPath } from 'node:url'
 
 import {
   loadSync,
@@ -12,12 +13,13 @@ register()
 registerHooks({ load: loadSync, resolve: resolveSync })
 
 let esmExports
+const esmPath = fileURLToPath(new URL('./typescript-abstract-hook.mts', import.meta.url))
 
 /**
  * @param {Record<string, unknown>} exports
  * @param {string} name
  */
-const hook = new Hook((exports, name) => {
+const hook = new Hook([esmPath], { replaceExports: [] }, (exports, name) => {
   if (name.endsWith('typescript-abstract-hook.mts')) {
     esmExports = Object.keys(exports)
   }

--- a/test/register/v18.19-export-capabilities.mjs
+++ b/test/register/v18.19-export-capabilities.mjs
@@ -1,4 +1,4 @@
-import { register } from 'node:module'
+import { register, syncBuiltinESMExports } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { rejects, strictEqual, throws } from 'node:assert/strict'
 
@@ -81,6 +81,17 @@ new Hook(['fs'], { replaceExports: [] }, namespace => {
   throws(() => { namespace.readFile = undefined }, { name: 'TypeError' })
 })
 
+// eslint-disable-next-line no-new
+new Hook(['fs'], { replaceExports: ['F_OK'] }, namespace => {
+  if ('F_OK' in namespace) namespace.F_OK = 1234
+})
+
+// eslint-disable-next-line no-new
+new Hook(['path'], { replaceExports: ['sep'] }, namespace => {
+  namespace.sep = 'hooked separator'
+  throws(() => { namespace.delimiter = undefined }, { name: 'TypeError' })
+})
+
 // Node.js 23 and later expose this marker on CommonJS namespaces.
 // eslint-disable-next-line no-new
 new Hook([commonJsPath], { replaceExports: [] }, namespace => {
@@ -108,6 +119,21 @@ strictEqual(reexport.val, 1)
 
 const fs = await import('node:fs')
 strictEqual(typeof fs.readFile, 'function')
+if ('F_OK' in fs.default) strictEqual(fs.F_OK, 1234)
+const originalReadFile = fs.default.readFile
+const replacementReadFile = () => {}
+try {
+  fs.default.readFile = replacementReadFile
+  syncBuiltinESMExports()
+  strictEqual(fs.readFile, replacementReadFile)
+} finally {
+  fs.default.readFile = originalReadFile
+  syncBuiltinESMExports()
+}
+
+const path = await import('node:path')
+strictEqual(path.sep, 'hooked separator')
+strictEqual(typeof path.join, 'function')
 
 const commonJs = await import(commonJsUrl)
 strictEqual(commonJs.foo, 'something')

--- a/test/register/v18.19-export-capabilities.mjs
+++ b/test/register/v18.19-export-capabilities.mjs
@@ -1,0 +1,153 @@
+import { register } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { rejects, strictEqual, throws } from 'node:assert/strict'
+
+import Hook, { addHook, createAddHookMessageChannel, removeHook } from '../../index.js'
+
+const liveUrl = new URL('../fixtures/export-capability-live.mjs', import.meta.url)
+const namedUrl = new URL('../fixtures/export-capability-named.mjs', import.meta.url)
+const defaultUrl = new URL('../fixtures/export-capability-default.mjs', import.meta.url)
+const commonJsUrl = new URL('../fixtures/index.js', import.meta.url)
+const reexportUrl = new URL('../fixtures/reexport-same-source.mjs', import.meta.url)
+const legacyUrl = new URL('../fixtures/export-capability-legacy.mjs', import.meta.url)
+const livePath = fileURLToPath(liveUrl)
+const namedPath = fileURLToPath(namedUrl)
+const defaultPath = fileURLToPath(defaultUrl)
+const commonJsPath = fileURLToPath(commonJsUrl)
+const reexportPath = fileURLToPath(reexportUrl)
+const legacyPath = fileURLToPath(legacyUrl)
+const { registerOptions, waitForAllMessagesAcknowledged } = createAddHookMessageChannel()
+
+throws(
+  () => new Hook([livePath], { replaceExports: 'all' }, () => {}),
+  { message: /array of export names/ }
+)
+throws(
+  () => new Hook([livePath], { replaceExports: [undefined] }, () => {}),
+  { message: /array of export names/ }
+)
+throws(
+  () => new Hook([livePath], { internals: true, replaceExports: [] }, () => {}),
+  { message: /incompatible/ }
+)
+
+register('../../hook.mjs', import.meta.url, registerOptions)
+
+// eslint-disable-next-line no-new
+new Hook([livePath], { replaceExports: [] }, namespace => {
+  namespace.state.hookCount++
+  namespace.init()
+  strictEqual(typeof namespace.Late, 'function')
+  strictEqual(Object.getOwnPropertyDescriptor(namespace, 'Late').value, namespace.Late)
+  throws(
+    () => { namespace.Late = undefined },
+    { name: 'TypeError', message: /not listed in 'replaceExports'/ }
+  )
+})
+
+const removedHook = new Hook([livePath], () => {})
+removedHook.unhook()
+const removedLowLevelHook = () => {}
+addHook(removedLowLevelHook)
+removeHook(removedLowLevelHook)
+
+// eslint-disable-next-line no-new
+new Hook([namedPath], { replaceExports: ['first'] }, namespace => {
+  namespace.state.hooked = true
+  namespace.first = 'hooked first'
+  throws(() => { namespace.untouched = 'changed' }, { name: 'TypeError' })
+  throws(
+    () => Object.defineProperty(namespace, 'untouched', { value: 'changed' }),
+    { name: 'TypeError' }
+  )
+})
+
+// eslint-disable-next-line no-new
+new Hook([namedPath], { replaceExports: ['second'] }, namespace => {
+  namespace.second = 'hooked second'
+})
+
+// eslint-disable-next-line no-new
+new Hook([defaultPath], { replaceExports: [] }, () => function replacement () {})
+
+// eslint-disable-next-line no-new
+new Hook([reexportPath], { replaceExports: [] }, namespace => {
+  strictEqual(namespace.val, 1)
+})
+
+// eslint-disable-next-line no-new
+new Hook(['fs'], { replaceExports: [] }, namespace => {
+  strictEqual(typeof namespace.readFile, 'function')
+  throws(() => { namespace.readFile = undefined }, { name: 'TypeError' })
+})
+
+// Node.js 23 and later expose this marker on CommonJS namespaces.
+// eslint-disable-next-line no-new
+new Hook([commonJsPath], { replaceExports: [] }, namespace => {
+  strictEqual(namespace.foo, 'something')
+  if ('module.exports' in namespace) {
+    throws(() => { namespace['module.exports'] = undefined }, { name: 'TypeError' })
+  }
+})
+
+await waitForAllMessagesAcknowledged()
+
+const live = await import('../fixtures/export-capability-live-consumer.mjs')
+strictEqual(live.Sub.name, 'Sub')
+strictEqual(live.AliasSub.name, 'AliasSub')
+strictEqual(live.state.hookCount, 1)
+
+const named = await import(namedUrl)
+strictEqual(named.state.hooked, true)
+strictEqual(named.first, 'hooked first')
+strictEqual(named.second, 'hooked second')
+strictEqual(named.untouched, 'original')
+
+const reexport = await import(reexportUrl)
+strictEqual(reexport.val, 1)
+
+const fs = await import('node:fs')
+strictEqual(typeof fs.readFile, 'function')
+
+const commonJs = await import(commonJsUrl)
+strictEqual(commonJs.foo, 'something')
+
+let futureHookCalls = 0
+let failedHighLevelCalls = 0
+let failedLowLevelCalls = 0
+// eslint-disable-next-line no-new
+new Hook([legacyPath], { replaceExports: [] }, namespace => {
+  futureHookCalls++
+  throws(
+    () => { namespace.value = 'changed' },
+    { name: 'TypeError', message: /not listed in 'replaceExports'/ }
+  )
+})
+throws(() => {
+  // eslint-disable-next-line no-new
+  new Hook([livePath, legacyPath], { replaceExports: [] }, () => {
+    failedHighLevelCalls++
+    throw new Error('high-level replay failed')
+  })
+}, { message: 'high-level replay failed' })
+throws(() => addHook(() => {
+  failedLowLevelCalls++
+  throw new Error('low-level replay failed')
+}), { message: 'low-level replay failed' })
+
+await waitForAllMessagesAcknowledged()
+
+const legacy = await import(legacyUrl)
+strictEqual(legacy.value, 'original')
+strictEqual(futureHookCalls, 1)
+strictEqual(failedHighLevelCalls, 1)
+strictEqual(failedLowLevelCalls, 1)
+
+await rejects(import(defaultUrl), { name: 'TypeError' })
+
+throws(() => {
+  // eslint-disable-next-line no-new
+  new Hook([livePath], { replaceExports: ['Late'] }, namespace => {
+    namespace.Late = class Replacement {}
+  })
+}, { name: 'TypeError' })

--- a/test/register/v18.19-export-capability-legacy-hook.mjs
+++ b/test/register/v18.19-export-capability-legacy-hook.mjs
@@ -1,0 +1,25 @@
+import { strictEqual } from 'node:assert/strict'
+import { register } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+import Hook, { createAddHookMessageChannel } from '../../index.js'
+
+const moduleUrl = new URL('../fixtures/export-capability-legacy.mjs', import.meta.url)
+const modulePath = fileURLToPath(moduleUrl)
+
+// eslint-disable-next-line no-new
+new Hook([modulePath], { replaceExports: [] }, () => {})
+
+const { registerOptions, waitForAllMessagesAcknowledged } = createAddHookMessageChannel()
+register('../../hook.mjs', import.meta.url, registerOptions)
+
+// A legacy hook for the same module keeps every export replaceable.
+// eslint-disable-next-line no-new
+new Hook([modulePath], namespace => {
+  namespace.value = 'hooked'
+})
+
+await waitForAllMessagesAcknowledged()
+
+const namespace = await import(moduleUrl)
+strictEqual(namespace.value, 'hooked')

--- a/test/register/v18.19-export-capability-low-level-hook.mjs
+++ b/test/register/v18.19-export-capability-low-level-hook.mjs
@@ -1,0 +1,22 @@
+import { strictEqual } from 'node:assert/strict'
+import { register } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+import Hook, { addHook, createAddHookMessageChannel } from '../../index.js'
+
+const moduleUrl = new URL('../fixtures/export-capability-legacy.mjs', import.meta.url)
+const modulePath = fileURLToPath(moduleUrl)
+const { registerOptions, waitForAllMessagesAcknowledged } = createAddHookMessageChannel()
+
+register('../../hook.mjs', import.meta.url, registerOptions)
+
+// eslint-disable-next-line no-new
+new Hook([modulePath], { replaceExports: [] }, () => {})
+addHook((url, namespace) => {
+  if (url === moduleUrl.href) namespace.value = 'hooked'
+})
+
+await waitForAllMessagesAcknowledged()
+
+const namespace = await import(moduleUrl)
+strictEqual(namespace.value, 'hooked')

--- a/test/register/v18.19-loader-url-escaping.mjs
+++ b/test/register/v18.19-loader-url-escaping.mjs
@@ -23,7 +23,8 @@ try {
     'lib/get-esm-exports.mjs',
     'lib/get-exports.mjs',
     'lib/io.mjs',
-    'lib/register.js'
+    'lib/register.js',
+    'lib/turbopack.js'
   ]
   const setupPromises = []
   for (const filename of packageFiles) {

--- a/test/register/v22.15-sync-export-capabilities.mjs
+++ b/test/register/v22.15-sync-export-capabilities.mjs
@@ -1,0 +1,77 @@
+import { throws, strictEqual } from 'node:assert/strict'
+import * as nodeModule from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+import Hook, { addHook } from '../../index.js'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  process.exit(0)
+}
+
+const liveUrl = new URL('../fixtures/export-capability-live.mjs', import.meta.url)
+const namedUrl = new URL('../fixtures/export-capability-named.mjs', import.meta.url)
+const livePath = fileURLToPath(liveUrl)
+const namedPath = fileURLToPath(namedUrl)
+let successfulHookCalls = 0
+
+process.env.TURBOPACK = '1'
+nodeModule.registerHooks({
+  resolve (specifier, context, nextResolve) {
+    return nextResolve(specifier === 'c8-reviewhash' ? 'c8/index.js' : specifier, context)
+  }
+})
+
+register({ include: [liveUrl.href, namedUrl.href, 'c8-reviewhash', 'date-fns'] })
+
+// eslint-disable-next-line no-new
+new Hook([livePath, namedPath], { replaceExports: [] }, namespace => {
+  successfulHookCalls++
+  if ('hookCount' in namespace.state) {
+    namespace.state.hookCount++
+  } else {
+    namespace.state.hooked = true
+  }
+})
+
+// eslint-disable-next-line no-new
+new Hook(['c8'], { replaceExports: [] }, namespace => {
+  strictEqual(typeof namespace.Report, 'function')
+  throws(() => { namespace.Report = undefined }, { name: 'TypeError' })
+})
+
+// The Turbopack normalization of date-fns is date, but the resolved package is still date-fns.
+// eslint-disable-next-line no-new
+new Hook(['date'], () => {
+  throw new Error('The date hook must not run for date-fns')
+})
+
+// eslint-disable-next-line no-new
+new Hook(['date-fns'], { replaceExports: [] }, namespace => {
+  strictEqual(typeof namespace.addDays, 'function')
+  throws(() => { namespace.addDays = undefined }, { name: 'TypeError' })
+})
+
+const live = await import('../fixtures/export-capability-live-consumer.mjs')
+strictEqual(live.Sub.name, 'Sub')
+strictEqual(live.state.hookCount, 1)
+
+throws(() => {
+  // eslint-disable-next-line no-new
+  new Hook([livePath, namedPath], { replaceExports: [] }, () => {
+    throw new Error('high-level replay failed')
+  })
+}, { message: 'high-level replay failed' })
+throws(() => addHook(() => {
+  throw new Error('low-level replay failed')
+}), { message: 'low-level replay failed' })
+
+const named = await import(namedUrl)
+strictEqual(named.state.hooked, true)
+strictEqual(successfulHookCalls, 2)
+
+const c8 = await import('c8-reviewhash')
+strictEqual(typeof c8.Report, 'function')
+
+const dateFns = await import('date-fns')
+strictEqual(typeof dateFns.addDays, 'function')

--- a/test/register/v22.15-sync-export-capability-turbopack-nested.mjs
+++ b/test/register/v22.15-sync-export-capability-turbopack-nested.mjs
@@ -1,0 +1,48 @@
+import { throws, strictEqual } from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import * as nodeModule from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import Hook from '../../index.js'
+import { register, supportsSyncHooks } from '../../register-hooks.mjs'
+
+if (!supportsSyncHooks()) {
+  process.exit(0)
+}
+
+const fixtureRoot = await mkdtemp(join(tmpdir(), 'iitm-turbopack-nested-'))
+const modulePath = join(fixtureRoot, 'node_modules', 'foo', 'node_modules', 'foo-bar', 'index.mjs')
+const moduleUrl = pathToFileURL(modulePath)
+
+try {
+  await mkdir(dirname(modulePath), { recursive: true })
+  await writeFile(modulePath, "export const value = 'original'\n")
+
+  process.env.TURBOPACK = '1'
+  nodeModule.registerHooks({
+    resolve (specifier, context, nextResolve) {
+      if (specifier === 'foo-reviewhash') return { url: moduleUrl.href, shortCircuit: true }
+      return nextResolve(specifier, context)
+    }
+  })
+
+  register({ include: ['foo-reviewhash'] })
+
+  // eslint-disable-next-line no-new
+  new Hook(['foo'], () => {
+    throw new Error('The outer package hook must not run for foo-bar')
+  })
+
+  // eslint-disable-next-line no-new
+  new Hook([modulePath], { replaceExports: [] }, namespace => {
+    strictEqual(namespace.value, 'original')
+    throws(() => { namespace.value = 'changed' }, { name: 'TypeError' })
+  })
+
+  const namespace = await import('foo-reviewhash')
+  strictEqual(namespace.value, 'original')
+} finally {
+  await rm(fixtureRoot, { recursive: true, force: true })
+}

--- a/test/register/v22.15-sync-register-hooks-builtin.mjs
+++ b/test/register/v22.15-sync-register-hooks-builtin.mjs
@@ -9,12 +9,15 @@
 import * as nodeModule from 'node:module'
 import { register, supportsSyncHooks } from '../../register-hooks.mjs'
 import Hook from '../../index.js'
-import { ok, strictEqual } from 'node:assert'
+import { ok, strictEqual, throws } from 'node:assert'
 
 if (!supportsSyncHooks()) {
   console.log(`Skipping ${process.env.IITM_TEST_FILE || import.meta.url}: synchronous hooks unsupported on this Node.js`)
   process.exit(0)
 }
+
+const nativeFs = await import('node:fs')
+nativeFs.default.iitmReviewCustom = 1
 
 register()
 
@@ -22,9 +25,10 @@ let eventsHookCount = 0
 let fsHookCount = 0
 
 // eslint-disable-next-line no-new
-new Hook(['events', 'fs'], (exports, name) => {
+new Hook(['events', 'fs'], { replaceExports: [] }, (exports, name) => {
   if (name === 'events') eventsHookCount++
   if (name === 'fs') fsHookCount++
+  throws(() => { exports.default = undefined }, { name: 'TypeError' })
 })
 
 const events = await import('node:events')
@@ -42,9 +46,12 @@ ok('kMaxEventTargetListeners' in events, 'non-enumerable own property should be 
 
 const fs = await import('node:fs')
 strictEqual(fsHookCount, 1, 'fs hook should fire exactly once')
+ok(!('iitmReviewCustom' in fs), 'late CommonJS properties should not become ESM exports')
+strictEqual(fs.default.iitmReviewCustom, 1, 'default should retain late CommonJS properties')
 strictEqual(typeof fs.readFileSync, 'function', 'readFileSync named export should be present')
 strictEqual(typeof fs.existsSync, 'function', 'existsSync named export should be present')
 strictEqual(typeof fs.default.readFileSync, 'function', 'default should carry the CJS exports')
+delete nativeFs.default.iitmReviewCustom
 
 // `module.registerHooks` also intercepts CommonJS `require()`. Unlike the ESM
 // imports above, a `require()` must return the native, mutable builtin rather

--- a/test/typescript/ts-node.test.mts
+++ b/test/typescript/ts-node.test.mts
@@ -16,4 +16,6 @@ new Hook((exported: any, name: string, baseDir: string|void)  => {
 
 });
 
+new Hook(['say-hi'], { replaceExports: ['sayHi'] as const }, () => {})
+
 assert.equal(sayHi('test'), 'Hooked')


### PR DESCRIPTION
Hooks that only mutate nested module values currently force IITM to create and synchronize a local cell for every export. This breaks delayed live bindings such as `class Sub extends Late` and adds startup work for export-heavy ESM modules.

This adds `replaceExports`: omitted keeps wildcard legacy behavior, an empty list preserves source live bindings, and named entries limit replacement to those bindings. The empty-list ESM fast path uses native re-exports and avoids per-export wrapper state; on 40 ESM modules with 251 exports it reduced import time 61–64% with sync hooks and 48–51% with async hooks across repeated trimmed trials. CommonJS, builtins, and named replacement sets retain the existing compatibility path.

Refs: https://github.com/nodejs/import-in-the-middle/issues/280