### PR TITLE
ci: add pull request benchmark reports

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -1,0 +1,109 @@
+name: Benchmark report
+
+on:
+  workflow_run:
+    workflows: [Benchmark]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  report:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-report
+          path: ${{ runner.temp }}/benchmark-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish benchmark report
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          ARTIFACT_DIRECTORY: ${{ runner.temp }}/benchmark-report
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('node:fs')
+            const path = require('node:path')
+            const marker = '<!-- import-in-the-middle-benchmark -->'
+            const names = ['No loader', 'Inactive loader', 'Active hook']
+            const source = fs.readFileSync(path.join(process.env.ARTIFACT_DIRECTORY, 'report.json'), 'utf8')
+            const report = JSON.parse(source)
+            const isDuration = (value) => Number.isFinite(value) && value > 0
+
+            if (report.formatVersion !== 1 || !Number.isInteger(report.prNumber) || report.prNumber < 1 ||
+              !/^[a-f0-9]{40}$/.test(report.baseSha) || !/^[a-f0-9]{40}$/.test(report.headSha) ||
+              report.headSha !== context.payload.workflow_run.head_sha ||
+              !/^v\d+\.\d+\.\d+$/.test(report.nodeVersion) || !Array.isArray(report.results) ||
+              report.results.length !== names.length) {
+              throw new Error('Invalid benchmark report')
+            }
+
+            for (let index = 0; index < names.length; index++) {
+              const result = report.results[index]
+              if (result?.name !== names[index] || !isDuration(result.baseMs) || !isDuration(result.headMs) ||
+                !Number.isFinite(result.changePercent)) {
+                throw new Error('Invalid benchmark result')
+              }
+            }
+
+            const pull = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: report.prNumber
+            })
+
+            if (pull.data.head.sha !== report.headSha) {
+              core.info('The pull request has a newer commit.')
+              return
+            }
+
+            const rows = report.results.map((result) => {
+              const change = `${result.changePercent >= 0 ? '+' : ''}${result.changePercent.toFixed(1)}%`
+              return `| ${result.name} | ${result.baseMs.toFixed(2)} ms | ${result.headMs.toFixed(2)} ms | ${change} |`
+            })
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.WORKFLOW_RUN_ID}`
+            const body = [
+              marker,
+              '## Benchmark report',
+              '',
+              `Node ${report.nodeVersion}. [Workflow run](${runUrl})`,
+              '',
+              '| Scenario | Base | Pull request | Change |',
+              '| --- | ---: | ---: | ---: |',
+              ...rows,
+              '',
+              `Base: \`${report.baseSha.slice(0, 7)}\` · Head: \`${report.headSha.slice(0, 7)}\``
+            ].join('\n')
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: report.prNumber
+            })
+            const existing = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker))
+
+            if (existing === undefined) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: report.prNumber,
+                body
+              })
+            } else {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              })
+            }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,52 @@
+name: Benchmark
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+      - run: npm install --ignore-scripts
+      - name: Check out the base revision
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git worktree add --detach "$RUNNER_TEMP/base" "$BASE_SHA"
+          npm install --ignore-scripts --prefix "$RUNNER_TEMP/base"
+      - name: Benchmark the base revision
+        run: >
+          node benchmark/run.mjs
+          --package-directory "$RUNNER_TEMP/base"
+          --output "$RUNNER_TEMP/base.json"
+      - name: Benchmark the pull request
+        run: >
+          node benchmark/run.mjs
+          --package-directory "$GITHUB_WORKSPACE"
+          --output "$RUNNER_TEMP/head.json"
+      - name: Build the benchmark report
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: >
+          node benchmark/compare.mjs
+          --base "$RUNNER_TEMP/base.json"
+          --head "$RUNNER_TEMP/head.json"
+          --output "$RUNNER_TEMP/report.json"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-report
+          path: ${{ runner.temp }}/report.json
+          if-no-files-found: error

--- a/benchmark/compare.mjs
+++ b/benchmark/compare.mjs
@@ -1,0 +1,98 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const options = parseOptions(process.argv.slice(2))
+const base = parseBenchmark(readFileSync(options.base, 'utf8'))
+const head = parseBenchmark(readFileSync(options.head, 'utf8'))
+const baseByName = new Map(base.benchmarks.map((benchmark) => [benchmark.name, benchmark.medianMs]))
+const results = []
+
+for (const benchmark of head.benchmarks) {
+  const baseMs = baseByName.get(benchmark.name)
+
+  if (baseMs === undefined) {
+    throw new Error(`Base benchmark is missing ${benchmark.name}`)
+  }
+
+  results.push({
+    name: benchmark.name,
+    baseMs,
+    headMs: benchmark.medianMs,
+    changePercent: ((benchmark.medianMs - baseMs) / baseMs) * 100
+  })
+}
+
+const report = {
+  formatVersion: 1,
+  prNumber: readPositiveInteger('PR_NUMBER'),
+  baseSha: readSha('BASE_SHA'),
+  headSha: readSha('HEAD_SHA'),
+  nodeVersion: head.nodeVersion,
+  results
+}
+
+writeFileSync(options.output, `${JSON.stringify(report, undefined, 2)}\n`)
+
+/**
+ * @param {string[]} argumentsList Command-line arguments.
+ * @returns {{ base: string, head: string, output: string }}
+ */
+function parseOptions (argumentsList) {
+  const values = new Map()
+
+  for (let index = 0; index < argumentsList.length; index += 2) {
+    values.set(argumentsList[index], argumentsList[index + 1])
+  }
+
+  const base = values.get('--base')
+  const head = values.get('--head')
+  const output = values.get('--output')
+
+  if (base === undefined || head === undefined || output === undefined || values.size !== 3) {
+    throw new Error('Expected --base, --head, and --output')
+  }
+
+  return { base: resolve(base), head: resolve(head), output: resolve(output) }
+}
+
+/**
+ * @param {string} source JSON benchmark report.
+ * @returns {{ nodeVersion: string, benchmarks: { name: string, medianMs: number }[] }}
+ */
+function parseBenchmark (source) {
+  const report = JSON.parse(source)
+
+  if (report.formatVersion !== 1 || typeof report.nodeVersion !== 'string' || !Array.isArray(report.benchmarks)) {
+    throw new Error('Invalid benchmark report')
+  }
+
+  return report
+}
+
+/**
+ * @param {string} name Environment variable name.
+ * @returns {number}
+ */
+function readPositiveInteger (name) {
+  const value = Number(process.env[name])
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+
+  return value
+}
+
+/**
+ * @param {string} name Environment variable name.
+ * @returns {string}
+ */
+function readSha (name) {
+  const value = process.env[name]
+
+  if (value === undefined || !/^[a-f0-9]{40}$/.test(value)) {
+    throw new Error(`${name} must be a full commit SHA`)
+  }
+
+  return value
+}

--- a/benchmark/fixture/a.mjs
+++ b/benchmark/fixture/a.mjs
@@ -1,0 +1,1 @@
+export const value = 1

--- a/benchmark/fixture/active-hook.cjs
+++ b/benchmark/fixture/active-hook.cjs
@@ -1,0 +1,14 @@
+const { resolve } = require('node:path')
+
+const packageRoot = process.env.IITM_BENCHMARK_PACKAGE_ROOT
+const fixtureRoot = process.env.IITM_BENCHMARK_FIXTURE_ROOT
+
+if (packageRoot === undefined || fixtureRoot === undefined) {
+  throw new Error('IITM_BENCHMARK_PACKAGE_ROOT and IITM_BENCHMARK_FIXTURE_ROOT are required')
+}
+
+const Hook = require(resolve(packageRoot, 'index.js'))
+
+Hook([resolve(fixtureRoot, 'a.mjs')], (exports) => {
+  exports.value += 1
+})

--- a/benchmark/fixture/app.mjs
+++ b/benchmark/fixture/app.mjs
@@ -1,0 +1,15 @@
+import { value as a } from './a.mjs'
+import { value as b } from './b.mjs'
+import { value as c } from './c.mjs'
+import { value as d } from './d.mjs'
+import { value as e } from './e.mjs'
+import { value as f } from './f.mjs'
+import { value as g } from './g.mjs'
+import { value as h } from './h.mjs'
+
+const expected = process.env.IITM_BENCHMARK_ACTIVE === '1' ? 88 : 87
+const sum = a + b + c + d + e + f + g + h
+
+if (sum !== expected) {
+  throw new Error(`Unexpected fixture result: ${sum}`)
+}

--- a/benchmark/fixture/b.mjs
+++ b/benchmark/fixture/b.mjs
@@ -1,0 +1,1 @@
+export const value = 2

--- a/benchmark/fixture/c.mjs
+++ b/benchmark/fixture/c.mjs
@@ -1,0 +1,1 @@
+export const value = 3

--- a/benchmark/fixture/d.mjs
+++ b/benchmark/fixture/d.mjs
@@ -1,0 +1,1 @@
+export const value = 5

--- a/benchmark/fixture/e.mjs
+++ b/benchmark/fixture/e.mjs
@@ -1,0 +1,1 @@
+export const value = 8

--- a/benchmark/fixture/f.mjs
+++ b/benchmark/fixture/f.mjs
@@ -1,0 +1,1 @@
+export const value = 13

--- a/benchmark/fixture/g.mjs
+++ b/benchmark/fixture/g.mjs
@@ -1,0 +1,1 @@
+export const value = 21

--- a/benchmark/fixture/h.mjs
+++ b/benchmark/fixture/h.mjs
@@ -1,0 +1,1 @@
+export const value = 34

--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -1,0 +1,125 @@
+import { spawnSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const benchmarkRoot = fileURLToPath(new URL('.', import.meta.url))
+const fixtureRoot = resolve(benchmarkRoot, 'fixture')
+const app = resolve(fixtureRoot, 'app.mjs')
+const activeHook = resolve(fixtureRoot, 'active-hook.cjs')
+
+const options = parseOptions(process.argv.slice(2))
+const packageRoot = resolve(options.packageDirectory)
+const results = runBenchmarks(packageRoot, options.runs)
+const report = {
+  formatVersion: 1,
+  nodeVersion: process.version,
+  benchmarks: results
+}
+
+if (options.output === undefined) {
+  process.stdout.write(`${JSON.stringify(report, undefined, 2)}\n`)
+} else {
+  writeFileSync(options.output, `${JSON.stringify(report, undefined, 2)}\n`)
+}
+
+/**
+ * @param {string[]} argumentsList Command-line arguments.
+ * @returns {{ output: string | undefined, packageDirectory: string, runs: number }}
+ */
+function parseOptions (argumentsList) {
+  let output
+  let packageDirectory = process.cwd()
+  let runs = 15
+
+  for (let index = 0; index < argumentsList.length; index++) {
+    const argument = argumentsList[index]
+    const value = argumentsList[index + 1]
+
+    if (argument === '--output' && value !== undefined) {
+      output = resolve(value)
+      index++
+    } else if (argument === '--package-directory' && value !== undefined) {
+      packageDirectory = value
+      index++
+    } else if (argument === '--runs' && value !== undefined) {
+      runs = Number(value)
+      index++
+    } else {
+      throw new Error(`Unknown or incomplete option: ${argument}`)
+    }
+  }
+
+  if (!Number.isInteger(runs) || runs < 1) {
+    throw new Error('--runs must be a positive integer')
+  }
+
+  return { output, packageDirectory, runs }
+}
+
+/**
+ * @param {string} packageDirectory Directory that contains import-in-the-middle.
+ * @param {number} runs Number of process starts measured for each scenario.
+ * @returns {{ name: string, medianMs: number }[]}
+ */
+function runBenchmarks (packageDirectory, runs) {
+  const loader = resolve(packageDirectory, 'hook.mjs')
+  const scenarios = [
+    { name: 'No loader', argumentsList: [app] },
+    { name: 'Inactive loader', argumentsList: ['--loader', loader, app] },
+    {
+      name: 'Active hook',
+      argumentsList: ['--require', activeHook, '--loader', loader, app],
+      environment: { IITM_BENCHMARK_ACTIVE: '1' }
+    }
+  ]
+
+  return scenarios.map((scenario) => ({
+    name: scenario.name,
+    medianMs: measureScenario(packageDirectory, scenario, runs)
+  }))
+}
+
+/**
+ * @param {string} packageDirectory Directory that contains import-in-the-middle.
+ * @param {{ argumentsList: string[], environment?: Record<string, string> }} scenario Benchmark invocation.
+ * @param {number} runs Number of process starts measured for the scenario.
+ * @returns {number}
+ */
+function measureScenario (packageDirectory, scenario, runs) {
+  const samples = []
+
+  for (let index = 0; index < runs; index++) {
+    const startedAt = process.hrtime.bigint()
+    const result = spawnSync(process.execPath, scenario.argumentsList, {
+      cwd: benchmarkRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        IITM_BENCHMARK_PACKAGE_ROOT: packageDirectory,
+        IITM_BENCHMARK_FIXTURE_ROOT: fixtureRoot,
+        ...scenario.environment,
+        NODE_NO_WARNINGS: '1'
+      }
+    })
+    const duration = Number(process.hrtime.bigint() - startedAt) / 1e6
+
+    if (result.status !== 0) {
+      throw new Error(`Benchmark process failed: ${result.stderr || result.stdout}`)
+    }
+
+    samples.push(duration)
+  }
+
+  samples.sort(compareNumbers)
+  return samples[Math.floor(samples.length / 2)]
+}
+
+/**
+ * @param {number} first First number.
+ * @param {number} second Second number.
+ * @returns {number}
+ */
+function compareNumbers (first, second) {
+  return first - second
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "node test/check-exports/test.mjs && node test/integration-tests/turbopack-dev.mjs && node test/integration-tests/turbopack-build-start.mjs",
     "test:ts": "c8 --reporter lcov imhotap --files test/typescript/*.test.mts",
     "coverage": "c8 --reporter html imhotap --files test/{hook,low-level,other,get-esm-exports,register}/* && echo \"\nNow open coverage/index.html\n\"",
+    "benchmark": "node benchmark/run.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
Adds startup benchmarks for inactive and active loader paths. The PR workflow compares the head with its base, and a separate artifact-only workflow updates one bot comment after validating its source SHA.